### PR TITLE
NOTICKET Add analytics skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "apollo",
-      "description": "Prospect, enrich leads, and load outreach sequences — one-click Apollo MCP server integration for Claude Code and Cowork.",
+      "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics — one-click Apollo MCP server integration for Claude Code and Cowork.",
       "source": "./",
       "homepage": "https://www.apollo.io/"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "version": "0.1.0",
-  "description": "Prospect, enrich leads, and load outreach sequences with Apollo.io — one-click MCP server integration for Claude Code and Cowork.",
+  "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics with Apollo.io — one-click MCP server integration for Claude Code and Cowork.",
   "author": {
     "name": "Apollo.io",
     "url": "https://www.apollo.io/"
@@ -9,5 +9,5 @@
   "repository": "https://github.com/apolloio/apollo-mcp-plugin",
   "homepage": "https://www.apollo.io/",
   "license": "MIT",
-  "keywords": ["apollo", "sales", "prospecting", "icp", "enrichment", "sequences", "mcp"]
+  "keywords": ["apollo", "sales", "prospecting", "icp", "enrichment", "sequences", "analytics", "mcp"]
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ High-value skills that chain multiple Apollo APIs into complete workflows:
 | `/apollo:enrich-lead` | Drop a name, LinkedIn URL, or email and get a full contact card with company context and next actions |
 | `/apollo:prospect` | Describe your ICP in plain English and get a ranked table of enriched decision-makers |
 | `/apollo:sequence-load` | Find leads, enrich them, dedupe, and bulk-add them to an Apollo sequence with a preview before enrollment |
+| `/apollo:analytics` | Ask any sales performance question and get formatted tables from real Apollo analytics data |
 
 
 ### `/apollo:enrich-lead`
@@ -41,6 +42,11 @@ Output: ranked lead table with enriched decision-makers
 Best for: taking action on a list. <br>
 Input: targeting criteria + target sequence <br>
 Output: preview of candidates, enrichment + dedupe, then bulk enrollment into the sequence
+
+### `/apollo:analytics`
+Best for: answering performance questions without opening a dashboard. <br>
+Input: any question about emails, calls, meetings, tasks, opportunities, sequences, or conversation intelligence <br>
+Output: formatted tables with real Apollo data, broken down by rep, team, time, sequence, stage, or any other dimension
 
 
 Important: sequence enrollment may trigger outbound depending on your sequence settings and sending configuration.
@@ -135,6 +141,7 @@ Try these in Claude:
 - “Enrich this lead: [https://www.linkedin.com/in/…”](https://www.linkedin.com/in/%E2%80%A6%E2%80%9D)
 - “Find 25 VP Sales at SaaS companies (200-1000 employees) that raised funding in the last 6 months.”
 - “Load the top 10 enriched leads into my sequence called ‘Q1 Enterprise Outbound’ and show me a preview before enrolling.”
+- “Show me email and call performance by rep for this quarter, sorted by calls made.”
 
 ---
 

--- a/skills/analytics/SKILL.md
+++ b/skills/analytics/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: analytics
+description: "Instant sales analytics. Ask any performance question — emails, calls, meetings, tasks, opportunities, sequences, conversation intelligence — and get formatted tables with real Apollo data."
+user-invocable: true
+argument-hint: [your analytics question]
+---
+
+# Analytics
+
+Answer any sales performance question using Apollo's analytics data. The user asks a question via "$ARGUMENTS".
+
+## Examples
+
+- `/apollo:analytics How many emails did I send last 30 days?`
+- `/apollo:analytics Show me team call connect rate this quarter by rep`
+- `/apollo:analytics What's our email reply rate week over week for this year?`
+- `/apollo:analytics Break down pipeline and won amount by opportunity stage all time`
+- `/apollo:analytics Which sequences have the highest reply rate in the last 6 months?`
+- `/apollo:analytics Show me activity summary — emails, calls, meetings, tasks — for each rep this quarter`
+- `/apollo:analytics How are calls trending by day of week over the last 3 months?`
+- `/apollo:analytics Show me emails sent vs replied broken down by contact stage and email type`
+
+## Step 1 — Interpret the Question
+
+Parse "$ARGUMENTS" to determine the following parameters:
+
+---
+
+### Metrics
+
+Select 1–15 metrics that match what the user is asking about. Always include the rate/percent version alongside raw counts when the user asks about performance.
+
+**Email**
+`num_emails_sent`, `num_emails_delivered`, `num_emails_opened`, `num_emails_clicked`, `num_emails_replied`, `num_emails_bounced`, `num_emails_unsubscribed`, `percent_emails_replied`, `num_contacts_emailed`, `num_contacts_opened`, `num_contacts_replied`
+
+**Calls**
+`num_phone_calls`, `num_phone_calls_completed`, `num_phone_calls_connect`, `num_phone_calls_connect_positive`, `num_phone_calls_connect_negative`, `num_phone_calls_connect_neutral`, `percent_phone_calls_connect`, `avg_phone_call_duration`, `num_contacts_called`
+
+Key distinctions:
+- `num_phone_calls_completed` = all logged attempts
+- `num_phone_calls_connect` = recipient actually answered
+- `num_phone_calls_connect_positive/negative/neutral` = connected calls by outcome sentiment
+
+**Meetings**
+`num_all_meetings_scheduled`, `num_meetings_held`, `num_all_meetings_rescheduled`, `num_calendar_events_scheduled`, `num_calendar_events_cancelled`, `num_all_meetings_scheduled_via_email`, `num_all_meetings_scheduled_via_call`
+
+Key distinctions:
+- `num_all_meetings_scheduled` = includes cancelled
+- `num_meetings_held` = actually occurred
+
+**Tasks**
+`num_tasks`, `num_tasks_completed`, `num_tasks_scheduled`, `num_tasks_completed_on_time`, `percent_tasks_completed`, `percent_tasks_completed_on_time`, `overdue_tasks`, `unfinished_overdue_tasks`
+
+Key distinctions:
+- `overdue_tasks` = all overdue including completed late
+- `unfinished_overdue_tasks` = still pending and overdue
+
+**Contacts & Accounts**
+`num_contacts`, `num_accounts`, `num_contacts_touched`, `num_accounts_touched`, `num_net_new_people`, `num_net_new_companies`, `num_contacts_with_job_change`
+
+**Opportunities**
+`num_opportunities`, `num_won`, `num_closed`, `deal_amount`, `won_amount`, `pipeline_amount`, `revenue_amount`, `avg_deal_amount`, `avg_won_amount`, `percent_win_rate`, `avg_salescycle_days`
+
+**Sequences**
+`num_contacts_added_to_sequence`, `num_contacts_remove_from_sequence`
+
+**Conversation Intelligence**
+`num_conversations_recorded`, `num_conversations_listened`, `avg_conversation_duration`, `total_conversation_duration`, `avg_talk_ratio`, `avg_question_rate`, `avg_longest_monologue`, `speaker_switches`
+
+**LinkedIn**
+`num_linkedin_tasks_scheduled`, `num_linkedin_tasks_completed`, `num_linkedin_tasks_skipped`, `percent_linkedin_tasks_completed`
+
+---
+
+### Date Range
+
+Map the user's time reference to a preset modality (preferred) or a custom range:
+
+**Presets**: `today`, `yesterday`, `current_week`, `current_month`, `current_quarter`, `current_year`, `last_7_days`, `last_2_weeks`, `last_30_days`, `last_3_months`, `last_6_months`, `last_12_months`, `last_4_quarters`, `last_2_years`, `previous_week`, `previous_month`, `previous_quarter`, `previous_year`, `all_time`
+
+**Custom**: use `range_start` + `range_end` (YYYY-MM-DD) for specific date windows. Do not combine with a modality.
+
+Default to `last_30_days` if no time reference is given.
+
+---
+
+### Breakdown (group_by)
+
+Does the user want data broken down by something? Set `group_by` to one of:
+
+**Time patterns** (for trends and time series)
+`smart_datetime_hour`, `smart_datetime_day`, `smart_datetime_week`, `smart_datetime_month`, `smart_datetime_year`
+`smart_datetime_hour_of_day`, `smart_datetime_day_of_week`, `smart_datetime_month_of_year`
+
+**People & Teams**
+`smart_user_id` (by rep), `smart_subteam_id` (by team)
+
+**Email dimensions**
+`emailer_campaign_id` (by sequence), `emailer_template_id` (by template), `emailer_message_type`, `emailer_step_id`, `emailer_touch_id`, `send_from_email`, `send_from_domain`, `email_account_id`
+
+**Calls**
+`phone_call_outcome_id`, `phone_call_purpose_id`, `phone_call_sentiment`
+
+**Contact attributes**
+`contact_stage_id`, `contact_label_ids`, `contact_owner_id`, `persona`, `person_title_unanalyzed`, `person_seniority`, `person_location_country`, `person_location_state`, `person_location_city`
+
+**Account & company attributes**
+`account_id`, `account_stage_id`, `account_label_ids`, `account_owner_id`, `organization_industries`, `organization_num_current_employees`, `organization_hq_location_country`, `organization_hq_location_state`, `organization_hq_location_city`, `organization_latest_funding_stage_cd`, `organization_current_technologies`
+
+**Opportunities**
+`opportunity_stage_id`, `opportunity_owner_id`, `opportunity_pipeline_id`, `forecast_category`, `lead_source`, `opportunity_deal_source`
+
+**Tasks**
+`task_type`, `task_status`
+
+**Conversations**
+`conversation_state`, `conversation_type`, `tracker_names_unanalyzed`, `calendar_event_setting_type`
+
+Omit `group_by` entirely for a flat summary (single row of totals).
+
+---
+
+### Pivot (pivot_group_by)
+
+If the user wants a cross-tab (e.g. "by rep AND by sequence", "broken down by stage vs email type"), set `group_by` to the primary dimension and `pivot_group_by` to the secondary. The tool returns one table per metric when a pivot is used. Prefer low-cardinality dimensions (e.g. `emailer_message_type`, `contact_stage_id`, `phone_call_sentiment`) as the pivot.
+
+---
+
+### Filters
+
+- "my data" / "for me" / "my performance" → `filters: { user_id: ["current"] }`
+- "team" / no user mention → omit filters entirely (returns team-wide data)
+
+---
+
+### Sort
+
+If the user asks "who has the most...", "ranked by...", or "top reps by...", set:
+```
+sort: { metric: "<metric_name>", asc: false }
+```
+Use `asc: true` for "lowest first" or "worst performing" queries.
+
+Two constraints:
+- Sort only applies when `group_by` is set — it has no effect on flat queries
+- The sort metric must be included in the `metrics` array
+
+---
+
+## Step 2 — Call the Analytics Tool
+
+Use `mcp__claude_ai_Apollo_MCP__apollo_analytics_sync_report` with the parameters determined above.
+
+If the question spans multiple independent dimensions (e.g. "show me email metrics by rep AND separately by sequence"), make two sequential calls.
+
+If the question is ambiguous, make a reasonable default call first, then offer to refine.
+
+---
+
+## Step 3 — Present the Results
+
+**Flat response** (no group_by): Present as a clean two-column summary table — metric name and value.
+
+**Grouped response** (group_by only): Present as a table with the dimension as the first column and metrics as subsequent columns. Highlight notable outliers (top performer, lowest rate, biggest gap).
+
+**Pivot response** (group_by + pivot_group_by): Present each metric as a separate labeled table. Add a brief summary sentence per table.
+
+Always:
+- Convert decimals to readable percentages (e.g. `0.14` → `14%`)
+- Format large numbers with commas
+- If the response says "Showing first N of M rows", mention the total count and offer to refine
+- Add 1–2 sentences of insight after the data (e.g. "Tuesday has the highest call volume at 355 calls", "Sarah Flores leads reply rate at 14%")
+
+---
+
+## Step 4 — Offer Follow-up Actions
+
+After presenting results, suggest 2–3 relevant next steps:
+
+1. **Drill deeper** — break down by another dimension (e.g. "want to see this by rep?")
+2. **Change date range** — compare with a different time period
+3. **Add more metrics** — "want to add meetings or tasks to this view?"
+4. **Pivot view** — "want to cross-tab this — e.g. by rep × sequence?"
+5. **Export** — format as CSV-style table for copy-paste


### PR DESCRIPTION
## Briefly describe what led to the creation of this PR

We shipped a new `apollo_analytics_sync_report` MCP action on the Apollo backend that gives Claude direct access to Apollo's sales analytics data. The plugin had no skill to expose or orchestrate this tool, so users wouldn't know it exists or how to use it effectively.

## Describe your changes

**New file: `skills/analytics/SKILL.md`**
Adds a new `/apollo:analytics` skill that lets users query Apollo analytics by asking natural language questions. The skill covers:
- Full metric catalog across all categories: email, calls, meetings, tasks, opportunities, sequences, conversation intelligence, LinkedIn
- All 19 date range modalities and custom date ranges
- All 53 relevant `group_by` dimensions (intentionally excludes `contact_id` and `opportunity_id` due to high cardinality)
- `pivot_group_by` for cross-tab queries
- `user_id` filter for scoping to current user vs team-wide data
- Sort with constraints (only applies with `group_by`, metric must be in metrics array)
- Output formatting guidance for flat, grouped, and pivot response shapes
- Follow-up action suggestions after each query

**Updated: `README.md`**
- Added `/apollo:analytics` to the skills table and added a dedicated section describing it
- Added one analytics example to Quickstart Examples

**Updated: `.claude-plugin/plugin.json`**
- Updated description to include analytics
- Added `"analytics"` to keywords

**Updated: `.claude-plugin/marketplace.json`**
- Updated plugin description to include analytics

## Any guidance to help the reviewer review this PR?

The SKILL.md format and structure exactly mirrors the existing skill files (`enrich-lead`, `prospect`, `sequence-load`) — same frontmatter fields, same step pattern, same tool reference format (`mcp__claude_ai_Apollo_MCP__apollo_analytics_sync_report`).

The analytics tool is read-only and does not consume Apollo credits, so no credit warning is needed (unlike enrich-lead).

Two intentional omissions from the `group_by` list:
- `contact_id` — would return one row per contact, not useful for aggregated analytics
- `opportunity_id` — same reason

## What manual and/or automated testing did you perform to validate this PR?

Ran 100 sequential tests against the production Apollo MCP server (`https://mcp.apollo.io/mcp`) covering:
- All metric categories (email, calls, meetings, tasks, opportunities, sequences, CI, LinkedIn)
- All 3 response shapes: flat, grouped, pivot
- All date range modalities including `today`, `yesterday`, `previous_*`, `all_time`, and custom `range_start`/`range_end`
- All major `group_by` dimensions including time patterns (hour_of_day, day_of_week, month_of_year), user, team, sequence, stage, geo, seniority, sentiment
- Multi-metric queries up to the 15-metric maximum
- Sort ascending and descending
- `user_id: current` filter
- Cross-tab pivots with multiple metrics

All 100 tests passed with no errors.

## Before/after pictures or videos

N/A — skill files and documentation only, no UI changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Verified SKILL.md format matches existing skill files exactly
- [x] Verified all metrics, date modalities, and group_by dimensions are accurate against the live MCP tool schema
- [x] Verified plugin.json, marketplace.json, and README are consistent with each other

## AI Tooling Contribution

- **ai_speed_boost_impact**
  - [x] 5 — _AI heavy-lift; I polished._

- **ai_ideation_help_impact**
  - [x] 4 — _Shaped the solution significantly._

## AI Documentation Usage

- **docs_used**: `skills/enrich-lead/SKILL.md`, `skills/prospect/SKILL.md`, `skills/sequence-load/SKILL.md`, `README.md`

- **docs_helpfulness_score**: 5

- **what_worked_well**: Existing skill files provided a clear, consistent template to follow. The format was unambiguous — frontmatter fields, step structure, and tool reference patterns were all directly reusable.

- **gaps**: No documentation on intentional omissions (e.g. which group_by dimensions to exclude for high cardinality). Determined by reasoning about the tool's use case.
