### PR TITLE
Document percent_unfinished_overdue_tasks in analytics skill

### DIFF
--- a/skills/analytics/SKILL.md
+++ b/skills/analytics/SKILL.md
@@ -49,11 +49,12 @@ Key distinctions:
 - `num_meetings_held` = actually occurred
 
 **Tasks**
-`num_tasks`, `num_tasks_completed`, `num_tasks_scheduled`, `num_tasks_completed_on_time`, `percent_tasks_completed`, `percent_tasks_completed_on_time`, `overdue_tasks`, `unfinished_overdue_tasks`
+`num_tasks`, `num_tasks_completed`, `num_tasks_scheduled`, `num_tasks_completed_on_time`, `percent_tasks_completed`, `percent_tasks_completed_on_time`, `overdue_tasks`, `unfinished_overdue_tasks`, `percent_unfinished_overdue_tasks`
 
 Key distinctions:
 - `overdue_tasks` = all overdue including completed late
 - `unfinished_overdue_tasks` = still pending and overdue
+- `percent_unfinished_overdue_tasks` = share of scheduled tasks that are overdue and unfinished (vs `num_tasks_scheduled`)
 
 **Contacts & Accounts**
 `num_contacts`, `num_accounts`, `num_contacts_touched`, `num_accounts_touched`, `num_net_new_people`, `num_net_new_companies`, `num_contacts_with_job_change`


### PR DESCRIPTION
## Summary
Aligns `/apollo:analytics` skill documentation with Leadgenie analytics MCP schema: adds `percent_unfinished_overdue_tasks` to the Tasks metric list and a short key-distinction note (share of scheduled tasks that are overdue and unfinished).

## Related
Pairs with Leadgenie `shared/configs/third_party_integrations/analytics.yml` exposing the same metric on `apollo_analytics_sync_report`.

## Testing
- Documentation-only; no code execution.

## Checklist
- [x] Self-reviewed
- [ ] JIRA ticket (add if required by team process)


Made with [Cursor](https://cursor.com)