### PR TITLE
Improve analytics skill filter support

### DIFF
--- a/skills/analytics/SKILL.md
+++ b/skills/analytics/SKILL.md
@@ -129,8 +129,11 @@ If the user wants a cross-tab (e.g. "by rep AND by sequence", "broken down by st
 
 ### Filters
 
-- "my data" / "for me" / "my performance" → `filters: { user_id: ["current"] }`
+- "my data" / "for me" / "my performance" → `filters: { user_ids: ["current"] }`
+- Specific user by Apollo user ID → `filters: { user_ids: ["<user_id>"] }` (can combine: `["current", "user_id_1"]`)
 - "team" / no user mention → omit filters entirely (returns team-wide data)
+- Filter by team/subteam → `filters: { team_ids: ["<subteam_id>"] }`
+- Filter by sequence name → first call `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_search` to resolve the name to an ID, then pass `filters: { emailer_campaign_ids: ["<id>"] }`
 
 ---
 


### PR DESCRIPTION
## What changed

Updated the analytics skill `Filters` section to stay in sync with the Apollo Analytics MCP tool schema improvements:

- `user_id` → `user_ids` (plural, consistent with MCP schema)
- Added support for arbitrary Apollo user IDs alongside `"current"` keyword
- Added `team_ids` filter
- Added `emailer_campaign_ids` filter with instruction to call `apollo_emailer_campaigns_search` first when user provides a sequence name

## Why

The MCP tool schema (`analytics.yml` in leadgenie) was updated in [PR #86119](https://github.com/apolloio/leadgenie/pull/86119). This PR keeps the plugin skill in sync so Claude follows the same filter conventions in both contexts.