### PR TITLE
Add glama.json, package.json (@apolloio/mcp), and server.json for MCP registries

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,5 @@
+{
+  "name": "Apollo",
+  "description": "Official Apollo.io MCP server — lead enrichment, prospecting, outreach sequences, and analytics. Access 275M+ contacts and 73M+ companies.",
+  "transport": "http+sse"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@apolloio/mcp",
+  "version": "0.1.1",
+  "description": "Official Apollo.io MCP server — connect Claude, Cursor, and other AI clients to Apollo's 275M+ contact database for lead enrichment, prospecting, and outreach sequences.",
+  "keywords": [
+    "mcp",
+    "apollo",
+    "apollo-io",
+    "sales",
+    "enrichment",
+    "prospecting",
+    "crm",
+    "leads"
+  ],
+  "homepage": "https://github.com/apolloio/apollo-mcp-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apolloio/apollo-mcp-plugin.git"
+  },
+  "license": "MIT",
+  "mcpName": "io.github.apolloio/mcp"
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.apolloio/mcp",
+  "description": "Official Apollo.io MCP server. Connect AI clients to Apollo's 275M+ contact and 73M+ company database for lead enrichment, prospecting, outreach sequence management, and sales analytics.",
+  "repository": {
+    "url": "https://github.com/apolloio/apollo-mcp-plugin",
+    "source": "github"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@apolloio/mcp",
+      "version": "0.1.1",
+      "transport": {
+        "type": "http+sse",
+        "url": "https://mcp.apollo.io/mcp"
+      }
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.apolloio/mcp",
-  "description": "Official Apollo.io MCP server. Connect AI clients to Apollo's 275M+ contact and 73M+ company database for lead enrichment, prospecting, outreach sequence management, and sales analytics.",
+  "description": "Official Apollo.io MCP server for lead enrichment, prospecting, sequences, and analytics.",
   "repository": {
     "url": "https://github.com/apolloio/apollo-mcp-plugin",
     "source": "github"
@@ -13,7 +13,7 @@
       "identifier": "@apolloio/mcp",
       "version": "0.1.1",
       "transport": {
-        "type": "http+sse",
+        "type": "streamable-http",
         "url": "https://mcp.apollo.io/mcp"
       }
     }


### PR DESCRIPTION
## What this adds

Three files to enable official Apollo MCP listings across distribution channels:

### `glama.json`
Metadata for Glama (glama.ai/mcp/servers) — the leading MCP server index. Once this is merged, submit the repo URL at Glama and it auto-indexes within minutes. Glama is also required for the awesome-mcp-servers PR (PR #9045 at punkpeye/awesome-mcp-servers is already open, awaiting the Glama URL).

### `package.json` (publishes as `@apolloio/mcp` on npm)
Thin metadata package required by the Official MCP Registry. Contains the `mcpName` field (`io.github.apolloio/mcp`) that links it to `server.json`.

To publish after merging:
```bash
npm publish --access public
```

### `server.json`
Manifest for the [Official MCP Registry](https://registry.modelcontextprotocol.io). After the npm package is live, run:
```bash
brew install mcp-publisher
mcp-publisher login github
mcp-publisher publish
```

This also gets Apollo listed in **GitHub Copilot**'s MCP registry automatically — it ingests from the official registry.

## Checklist after merging
- [ ] Run `npm publish --access public` to publish `@apolloio/mcp` to npm
- [ ] Submit repo URL to Glama → add listing URL to the awesome-mcp-servers PR
- [ ] Run `mcp-publisher publish` to register in the official MCP Registry