### PR TITLE
Improve Apollo MCP skills and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,85 @@
-# Apollo Plugin for Claude Code and Cowork
+# Apollo MCP Plugin
 
-Prospect, enrich leads, and add to outreach sequences with [Apollo.io](https://www.apollo.io/) MCP Server
+Connect the [Apollo.io](https://www.apollo.io/) MCP Server to Claude Code, Cowork, and Cursor to prospect, enrich leads, prepare outreach sequences, and query sales analytics.
+
 - Fast to install.
 - Powerful in execution.
 - Designed for real GTM workflows.
 
 ---
 
-## 🔌 One-Click MCP Server Integration
+## One-Click MCP Server Integration
 
-This plugin automatically configures the Apollo MCP Server when installed.
-No manual server setup or config files.
-Install the plugin, authenticate with Apollo, and run `/apollo:*` commands.
+This repository packages the Apollo MCP integration for Claude Code, Cowork, and Cursor. Install the plugin for your client, authenticate with Apollo, and start working with Apollo in your agent.
+
+It also includes reusable Apollo workflow skills. Skill discovery and loading depend on the capabilities of each client; connecting the MCP makes Apollo tools available but does not guarantee that every client automatically installs or invokes these skill files.
 
 ---
 
-## ✅ Powerful Skills
+## Powerful Skills
 
-High-value skills that chain multiple Apollo APIs into complete workflows:
+High-value skills that guide Apollo workflows from a user's goal to a safe, useful outcome.
 
 | Skill | What it does |
-|---|---|
-| `/apollo:enrich-lead` | Drop a name, LinkedIn URL, or email and get a full contact card with company context and next actions |
-| `/apollo:prospect` | Describe your ICP in plain English and get a ranked table of enriched decision-makers |
-| `/apollo:sequence-load` | Find leads, enrich them, dedupe, and bulk-add them to an Apollo sequence with a preview before enrollment |
-| `/apollo:analytics` | Ask any sales performance question and get formatted tables from real Apollo analytics data |
+| --- | --- |
+| `/apollo:onboarding` | Learn Apollo MCP capabilities, run safe first checks, and choose the right workflow. |
+| `/apollo:enrich-lead` | Match and enrich a lead with explicit credit confirmation. |
+| `/apollo:prospect` | Describe your ICP and get a ranked, search-first prospect shortlist. |
+| `/apollo:sequence-load` | Prepare contacts for a sequence with separate approval before real-world changes. |
+| `/apollo:analytics` | Ask sales performance questions and get read-only Apollo analytics. |
+| `/apollo:inbound-website-visitors` | Set up Apollo website visitor tracking with explicit setup, update, and email gates. |
 
+### `/apollo:onboarding`
+
+Best for: getting oriented, testing the connection safely, and choosing the right Apollo workflow.<br>
+Input: a question or workflow<br>
+Output: capability menu, risk-level guidance, safe first test, and recommended specialist skill
 
 ### `/apollo:enrich-lead`
 
-Best for: one-off enrichment and fast lead lookups. <br>
-Input: name, company, LinkedIn URL, or email <br>
-Output: enriched profile (role, location, company context) and suggested next steps
+Best for: one-off enrichment and fast lead lookups.<br>
+Input: name, company, LinkedIn URL, or email<br>
+Output: likely matches first, then enriched profile and suggested next steps after confirmation
 
 ### `/apollo:prospect`
-Best for: turning an ICP into a shortlist fast. <br>
-Input: ICP description (industry, size, geography, titles) <br>
-Output: ranked lead table with enriched decision-makers
+
+Best for: turning an ICP into a search-first shortlist.<br>
+Input: ICP description (industry, size, geography, titles)<br>
+Output: ranked prospect table; enrichment is offered only after confirmation
 
 ### `/apollo:sequence-load`
-Best for: taking action on a list. <br>
-Input: targeting criteria + target sequence <br>
-Output: preview of candidates, enrichment + dedupe, then bulk enrollment into the sequence
+
+Best for: safely preparing contacts for a sequence.<br>
+Input: targeting criteria and target sequence<br>
+Output: candidate preview with separate gates for enrichment, contact creation, enrollment, and activation
 
 ### `/apollo:analytics`
-Best for: answering performance questions without opening a dashboard. <br>
-Input: any question about emails, calls, meetings, tasks, opportunities, sequences, or conversation intelligence <br>
-Output: formatted tables with real Apollo data, broken down by rep, team, time, sequence, stage, or any other dimension
 
+Best for: answering performance questions without opening a dashboard.<br>
+Input: any question about emails, calls, meetings, tasks, opportunities, sequences, or conversation intelligence<br>
+Output: formatted tables with Apollo data, broken down by rep, team, time, sequence, stage, or another supported dimension
 
-Important: sequence enrollment may trigger outbound depending on your sequence settings and sending configuration.
+### `/apollo:inbound-website-visitors`
 
----
+Best for: setting up Apollo website visitor tracking on a site.<br>
+Input: website or domain context<br>
+Output: tracker status, official install guidance when available, and gated update or email steps
 
-## 🧠 Model Recommendations (Quality-First)
-
-Recommended: Opus (best quality)
-
-Use Opus when you want the strongest reasoning and the most reliable multi-step tool orchestration.
-
-- Best for: prospecting workflows, ambiguous matches, multi-step chaining, and anything high-stakes
-- Tradeoff: higher latency and higher model usage cost on the Anthropic side
-
-### Strong fallback: Sonnet (faster)
-
-Use Sonnet when you want speed for quick lookups, smaller jobs, or rapid iteration.
-
-- Best for: quick searches, lightweight enrichment, and tight loops
-- Tradeoff: may require more user guidance for complex multi-step workflows
-
-In Claude Code, you can switch models via `/model`.
-
+Important: sequence enrollment may trigger outbound depending on sequence settings and sending configuration.
 
 ---
 
-## 📦 Installation
+## Model Recommendations
+
+Recommended: Opus for complex prospecting workflows, ambiguous matches, and multi-step orchestration.
+
+Use Sonnet when speed matters for quick lookups, smaller jobs, or rapid iteration. In Claude Code, switch models with `/model`.
+
+---
+
+## Installation
 
 ### Cowork
-
-Click the link below to install in one step:
 
 [Install in Cowork](https://claude.ai/desktop/customize/plugins/new?marketplace=apolloio/apollo-mcp-plugin&plugin=apollo)
 
@@ -86,78 +87,70 @@ Then restart Cowork to ensure the MCP server starts correctly.
 
 ### Claude Code
 
-#### 1. Add this plugin's marketplace
+1. Add this plugin's marketplace:
 
-In Claude Code, run:
-
-```
+```text
 /plugin marketplace add apolloio/apollo-mcp-plugin
 ```
 
-#### 2. Install the plugin
+2. Install the plugin:
 
-```
+```text
 /plugin install apollo@apollo-plugin-marketplace
 ```
 
-#### 3. Restart Claude Code
-
-This ensures the MCP server starts correctly.
+3. Restart Claude Code.
 
 ### Cursor
 
-1. Open Cursor and go to the Plugin Marketplace
-2. Search for "Apollo" and install
-3. Authenticate with your Apollo.io account when prompted
+1. Open Cursor and go to the Plugin Marketplace.
+2. Search for "Apollo" and install the plugin.
+3. Authenticate with your Apollo account when prompted.
 
 ---
 
-## 🔑 Authentication
+## Authentication
 
-The Apollo MCP Server supports **OAuth**:
+The Apollo MCP Server supports OAuth:
 
-1. After installation, run `/mcp` in Claude Code or `connect` to Apollo.io connector from settings
-2. Select the **Apollo** server and click **Authenticate**
-3. Complete the Apollo.io login in your browser
-4. Done — all commands are now ready to use
+1. After installation, run `/mcp` in Claude Code or connect to the Apollo connector from settings.
+2. Select the Apollo server and click **Authenticate**.
+3. Complete the Apollo login in your browser.
 
 ---
 
-## **⚠️** Apollo Credits and Safety
+## Apollo Credits and Safety
 
 Some operations consume Apollo credits:
 
-- People enrichment typically costs 1 credit per person
-- Bulk enrichment consumes credits based on how many people are enriched
+- People enrichment typically costs one credit per person.
+- Bulk enrichment consumes credits based on the number of people enriched.
 
-This plugin is designed to warn and request confirmation before credit-consuming actions by default.
+This plugin asks for confirmation immediately before credit-consuming actions.
 
 Sequence safety:
 
-- Adding contacts to a sequence can enroll them into an active sequence
-- Depending on your sequence settings, outbound may start automatically
-- Always verify your sequence name, sending account, and enrollment volume before confirming
+- Adding contacts to a sequence can enroll them into an active sequence.
+- Depending on sequence settings, outbound may start automatically.
+- Verify the sequence name, sending account, and enrollment volume before confirming.
 
 ---
 
 ## Quickstart Examples
 
-Try these in Claude:
-
-- “Enrich this lead: [https://www.linkedin.com/in/…”](https://www.linkedin.com/in/%E2%80%A6%E2%80%9D)
-- “Find 25 VP Sales at SaaS companies (200-1000 employees) that raised funding in the last 6 months.”
-- “Load the top 10 enriched leads into my sequence called ‘Q1 Enterprise Outbound’ and show me a preview before enrolling.”
-- “Show me email and call performance by rep for this quarter, sorted by calls made.”
+- `Find VP Sales at SaaS companies with 200-1,000 employees that raised funding in the last six months. Show search results first and confirm before charging credits.`
+- `Prepare the top ten matched prospects for my sequence called Q1 Enterprise Outbound. Show a preview and ask separately before enrichment, contact creation, enrollment, or activation.`
+- `Show email and call performance by rep for this quarter, sorted by calls made.`
 
 ---
 
-## 🙌 Credits
+## Credits
 
-- **MCP Server** by [Apollo.io](https://docs.apollo.io/)
-- **Plugin Specification** by [Anthropic](https://docs.anthropic.com/)
+- MCP Server by [Apollo.io](https://www.apollo.io/)
+- Plugin Specification by [Anthropic](https://docs.anthropic.com/)
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT - see [LICENSE](LICENSE) for details.

--- a/skills/analytics/SKILL.md
+++ b/skills/analytics/SKILL.md
@@ -1,188 +1,158 @@
 ---
 name: analytics
-description: "Instant sales analytics. Ask any performance question — emails, calls, meetings, tasks, opportunities, sequences, conversation intelligence — and get formatted tables with real Apollo data."
+description: "Answer Apollo sales analytics questions with read-only reports. Use for performance questions about emails, calls, meetings, tasks, opportunities, sequences, and conversation intelligence."
 user-invocable: true
 argument-hint: [your analytics question]
 ---
 
 # Analytics
 
-Answer any sales performance question using Apollo's analytics data. The user asks a question via "$ARGUMENTS".
+Answer any sales performance question using Apollo analytics. This skill is read-only. The user asks a question via `$ARGUMENTS`.
 
 ## Examples
+
+In Replit, ask for the same workflow in natural language. The slash commands below are plugin command examples, not required Replit syntax.
 
 - `/apollo:analytics How many emails did I send last 30 days?`
 - `/apollo:analytics Show me team call connect rate this quarter by rep`
 - `/apollo:analytics What's our email reply rate week over week for this year?`
 - `/apollo:analytics Break down pipeline and won amount by opportunity stage all time`
 - `/apollo:analytics Which sequences have the highest reply rate in the last 6 months?`
-- `/apollo:analytics Show me activity summary — emails, calls, meetings, tasks — for each rep this quarter`
-- `/apollo:analytics How are calls trending by day of week over the last 3 months?`
-- `/apollo:analytics Show me emails sent vs replied broken down by contact stage and email type`
 
-## Step 1 — Interpret the Question
+## Step 0 - Confirm Available Tools
 
-Parse "$ARGUMENTS" to determine the following parameters:
+Use the Apollo tools exposed by the current client. Tool names vary by client.
 
----
+Needed capabilities:
 
-### Metrics
+- analytics report, such as `apollo_analytics_sync_report`
+- optional sequence search for resolving sequence-name filters, such as `apollo_emailer_campaigns_search`
 
-Select 1–15 metrics that match what the user is asking about. Always include the rate/percent version alongside raw counts when the user asks about performance.
+When using sequence search, follow the parameter types exposed by the current client for `page` and `per_page`. Some clients expose numeric paging semantics as string-typed schema fields. Use small values such as page 1 and per_page 1, and if the client or server rejects paging because of a schema mismatch, stop and report a `tool/schema` blocker rather than retrying blindly.
 
-**Email**
-`num_emails_sent`, `num_emails_delivered`, `num_emails_opened`, `num_emails_clicked`, `num_emails_replied`, `num_emails_bounced`, `num_emails_unsubscribed`, `percent_emails_replied`, `num_contacts_emailed`, `num_contacts_opened`, `num_contacts_replied`
+If the analytics tool is unavailable, explain the missing capability and do not invent data.
 
-**Calls**
-`num_phone_calls`, `num_phone_calls_completed`, `num_phone_calls_connect`, `num_phone_calls_connect_positive`, `num_phone_calls_connect_negative`, `num_phone_calls_connect_neutral`, `percent_phone_calls_connect`, `avg_phone_call_duration`, `num_contacts_called`
+## Step 1 - Interpret the Question
+
+Identify:
+
+- metrics
+- date range
+- grouping
+- pivot grouping, if requested
+- filters
+- sort order
+
+Default date range:
+
+- Use `last_30_days` if the user gives no time reference.
+- Use the current date when resolving relative ranges.
+
+## Step 2 - Choose Metrics
+
+Select 1-15 metrics that match the question. Include rate or percentage metrics alongside raw counts when the user asks about performance.
+
+Use Apollo metric IDs internally, but translate them into seller-facing labels in the response unless the user is debugging a metric mapping. Prefer labels like Reply rate, Meetings booked, Call connect rate, Open rate, Bounce rate, Tasks completed, Pipeline amount, and Win rate.
+
+Common metric names:
+
+- email: `num_emails_sent`, `num_emails_scheduled`, `num_emails_delivered`, `num_emails_opened`, `num_emails_clicked`, `num_emails_replied`, `num_emails_bounced`, `num_emails_unsubscribed`, `percent_emails_replied`, `num_contacts_emailed`, `num_contacts_opened`, `num_contacts_replied`, `email_daily_limit`
+- calls: `num_phone_calls`, `num_phone_calls_completed`, `num_phone_calls_connect`, `num_phone_calls_connect_positive`, `num_phone_calls_connect_negative`, `num_phone_calls_connect_neutral`, `percent_phone_calls_connect`, `avg_phone_call_duration`, `num_contacts_called`
+- meetings: `num_all_meetings_scheduled`, `num_meetings_held`, `num_all_meetings_rescheduled`, `num_calendar_events_scheduled`, `num_calendar_events_cancelled`, `num_all_meetings_scheduled_via_email`, `num_all_meetings_scheduled_via_call`
+- tasks: `num_tasks`, `num_tasks_completed`, `num_tasks_scheduled`, `num_tasks_completed_on_time`, `percent_tasks_completed`, `percent_tasks_completed_on_time`, `overdue_tasks`, `unfinished_overdue_tasks`, `percent_unfinished_overdue_tasks`
+- contacts/accounts: `num_contacts`, `num_accounts`, `num_contacts_touched`, `num_accounts_touched`, `num_net_new_people`, `num_net_new_companies`, `num_contacts_with_job_change`
+- opportunities: `num_opportunities`, `num_won`, `num_closed`, `deal_amount`, `won_amount`, `pipeline_amount`, `revenue_amount`, `avg_deal_amount`, `avg_won_amount`, `percent_win_rate`, `avg_salescycle_days`
+- sequences: `num_contacts_added_to_sequence`, `num_contacts_remove_from_sequence`
+- conversations: `num_conversations_recorded`, `num_conversations_listened`, `avg_conversation_duration`, `total_conversation_duration`, `avg_talk_ratio`, `avg_question_rate`, `avg_longest_monologue`, `speaker_switches`
+- LinkedIn: `num_linkedin_tasks_scheduled`, `num_linkedin_tasks_completed`, `num_linkedin_tasks_skipped`, `percent_linkedin_tasks_completed`
 
 Key distinctions:
-- `num_phone_calls_completed` = all logged attempts
-- `num_phone_calls_connect` = recipient actually answered
-- `num_phone_calls_connect_positive/negative/neutral` = connected calls by outcome sentiment
 
-**Meetings**
-`num_all_meetings_scheduled`, `num_meetings_held`, `num_all_meetings_rescheduled`, `num_calendar_events_scheduled`, `num_calendar_events_cancelled`, `num_all_meetings_scheduled_via_email`, `num_all_meetings_scheduled_via_call`
+- `num_phone_calls_completed` means logged call attempts; `num_phone_calls_connect` means the recipient answered.
+- `num_all_meetings_scheduled` may include cancelled meetings; `num_meetings_held` means meetings that occurred.
+- `overdue_tasks` includes completed-late tasks; `unfinished_overdue_tasks` means tasks still pending and overdue.
+- `percent_unfinished_overdue_tasks` is the share of scheduled tasks that are overdue and unfinished.
+- `email_daily_limit` is the configured daily outbound sending limit. Combine it with email volume and a user, mailbox, or time grouping when comparing activity to that limit.
+- `avg_talk_ratio`, `avg_question_rate`, `avg_longest_monologue`, and `speaker_switches` are conversation intelligence metrics.
 
-Key distinctions:
-- `num_all_meetings_scheduled` = includes cancelled
-- `num_meetings_held` = actually occurred
+## Step 3 - Choose Date Range
 
-**Tasks**
-`num_tasks`, `num_tasks_completed`, `num_tasks_scheduled`, `num_tasks_completed_on_time`, `percent_tasks_completed`, `percent_tasks_completed_on_time`, `overdue_tasks`, `unfinished_overdue_tasks`, `percent_unfinished_overdue_tasks`
+Use a supported preset when possible:
 
-Key distinctions:
-- `overdue_tasks` = all overdue including completed late
-- `unfinished_overdue_tasks` = still pending and overdue
-- `percent_unfinished_overdue_tasks` = share of scheduled tasks that are overdue and unfinished (vs `num_tasks_scheduled`)
+`today`, `yesterday`, `current_week`, `current_month`, `current_quarter`, `current_year`, `last_7_days`, `last_2_weeks`, `last_30_days`, `last_3_months`, `last_6_months`, `last_12_months`, `last_4_quarters`, `last_2_years`, `previous_week`, `previous_month`, `previous_quarter`, `previous_year`, `all_time`.
 
-**Contacts & Accounts**
-`num_contacts`, `num_accounts`, `num_contacts_touched`, `num_accounts_touched`, `num_net_new_people`, `num_net_new_companies`, `num_contacts_with_job_change`
+For specific date windows, use `range_start` and `range_end` in `YYYY-MM-DD` format if supported by the visible tool schema. Do not combine a preset with custom range fields.
 
-**Opportunities**
-`num_opportunities`, `num_won`, `num_closed`, `deal_amount`, `won_amount`, `pipeline_amount`, `revenue_amount`, `avg_deal_amount`, `avg_won_amount`, `percent_win_rate`, `avg_salescycle_days`
+Default to `last_30_days` if the user gives no time reference.
 
-**Sequences**
-`num_contacts_added_to_sequence`, `num_contacts_remove_from_sequence`
+## Step 4 - Choose Groupings
 
-**Conversation Intelligence**
-`num_conversations_recorded`, `num_conversations_listened`, `avg_conversation_duration`, `total_conversation_duration`, `avg_talk_ratio`, `avg_question_rate`, `avg_longest_monologue`, `speaker_switches`
+Use `group_by` when the user asks for a breakdown:
 
-**LinkedIn**
-`num_linkedin_tasks_scheduled`, `num_linkedin_tasks_completed`, `num_linkedin_tasks_skipped`, `percent_linkedin_tasks_completed`
+- time trends: `smart_datetime_hour`, `smart_datetime_day`, `smart_datetime_week`, `smart_datetime_month`, `smart_datetime_year`, `smart_datetime_hour_of_day`, `smart_datetime_day_of_week`, `smart_datetime_month_of_year`
+- people and teams: `smart_user_id`, `smart_subteam_id`
+- email and sequences: `emailer_campaign_id`, `emailer_template_id`, `emailer_message_type`, `emailer_step_id`, `emailer_touch_id`, `send_from_email`, `send_from_domain`, `email_account_id`
+- calls: `phone_call_outcome_id`, `phone_call_purpose_id`, `phone_call_sentiment`
+- contacts: `contact_id`, `contact_stage_id`, `contact_label_ids`, `contact_owner_id`, `persona`, `person_title_unanalyzed`, `person_seniority`, `person_location_country`, `person_location_state`, `person_location_city`
+- accounts and companies: `account_id`, `account_stage_id`, `account_label_ids`, `account_owner_id`, `organization_industries`, `organization_num_current_employees`, `organization_hq_location_country`, `organization_hq_location_state`, `organization_hq_location_city`, `organization_latest_funding_stage_cd`, `organization_current_technologies`
+- opportunities: `opportunity_id`, `opportunity_stage_id`, `opportunity_owner_id`, `opportunity_pipeline_id`, `forecast_category`, `lead_source`, `opportunity_deal_source`
+- tasks: `task_type`, `task_status`
+- conversations: `conversation_state`, `conversation_type`, `tracker_names_unanalyzed`, `calendar_event_setting_type`
 
----
+Use `pivot_group_by` for cross-tabs, such as rep by sequence or stage by email type. Prefer low-cardinality pivot fields like `emailer_message_type`, `contact_stage_id`, or `phone_call_sentiment`.
 
-### Date Range
+## Step 5 - Resolve Filters And Sort Safely
 
-Map the user's time reference to a preset modality (preferred) or a custom range:
+If the user asks for a sequence by name, use sequence search only to resolve the ID, then run the analytics report.
 
-**Presets**: `today`, `yesterday`, `current_week`, `current_month`, `current_quarter`, `current_year`, `last_7_days`, `last_2_weeks`, `last_30_days`, `last_3_months`, `last_6_months`, `last_12_months`, `last_4_quarters`, `last_2_years`, `previous_week`, `previous_month`, `previous_quarter`, `previous_year`, `all_time`
+Map common filters:
 
-**Custom**: use `range_start` + `range_end` (YYYY-MM-DD) for specific date windows. Do not combine with a modality.
+- "my data" or "for me": use current-user filtering if supported by the tool.
+- specific users or teams: use user or team IDs only when they are visible from safe context or a confirmed lookup.
+- sequence name: resolve to an `emailer_campaign_id` before filtering.
 
-Default to `last_30_days` if no time reference is given.
+If the user asks for "top", "ranked by", "highest", "lowest", or "worst", sort by a metric already included in the `metrics` array. Sorting usually only matters when `group_by` is present.
 
----
+Do not create, update, enroll, approve, or activate anything while answering analytics questions.
 
-### Breakdown (group_by)
+## Step 6 - Call the Analytics Report
 
-Does the user want data broken down by something? Set `group_by` to one of:
+Call the available analytics report tool with the interpreted parameters.
 
-**Time patterns** (for trends and time series)
-`smart_datetime_hour`, `smart_datetime_day`, `smart_datetime_week`, `smart_datetime_month`, `smart_datetime_year`
-`smart_datetime_hour_of_day`, `smart_datetime_day_of_week`, `smart_datetime_month_of_year`
+If the question spans separate dimensions, use multiple read-only report calls rather than overloading one request.
 
-**People & Teams**
-`smart_user_id` (by rep), `smart_subteam_id` (by team)
+If the question is ambiguous, choose a reasonable read-only default and state it briefly.
 
-**Email dimensions**
-`emailer_campaign_id` (by sequence), `emailer_template_id` (by template), `emailer_message_type`, `emailer_step_id`, `emailer_touch_id`, `send_from_email`, `send_from_domain`, `email_account_id`
+## Step 7 - Present Results
 
-**Calls**
-`phone_call_outcome_id`, `phone_call_purpose_id`, `phone_call_sentiment`
+For flat results, present a two-column table:
 
-**Contact attributes**
-`contact_stage_id`, `contact_label_ids`, `contact_owner_id`, `persona`, `person_title_unanalyzed`, `person_seniority`, `person_location_country`, `person_location_state`, `person_location_city`
+| Metric | Value |
+|---|---|
 
-**Account & company attributes**
-`account_id`, `account_stage_id`, `account_label_ids`, `account_owner_id`, `organization_industries`, `organization_num_current_employees`, `organization_hq_location_country`, `organization_hq_location_state`, `organization_hq_location_city`, `organization_latest_funding_stage_cd`, `organization_current_technologies`
+For grouped results, use the group as the first column and seller-facing metric labels as subsequent columns.
 
-**Opportunities**
-`opportunity_stage_id`, `opportunity_owner_id`, `opportunity_pipeline_id`, `forecast_category`, `lead_source`, `opportunity_deal_source`
-
-**Tasks**
-`task_type`, `task_status`
-
-**Conversations**
-`conversation_state`, `conversation_type`, `tracker_names_unanalyzed`, `calendar_event_setting_type`
-
-Omit `group_by` entirely for a flat summary (single row of totals).
-
----
-
-### Pivot (pivot_group_by)
-
-If the user wants a cross-tab (e.g. "by rep AND by sequence", "broken down by stage vs email type"), set `group_by` to the primary dimension and `pivot_group_by` to the secondary. The tool returns one table per metric when a pivot is used. Prefer low-cardinality dimensions (e.g. `emailer_message_type`, `contact_stage_id`, `phone_call_sentiment`) as the pivot.
-
----
-
-### Filters
-
-- "my data" / "for me" / "my performance" → `filters: { user_ids: ["current"] }`
-- Specific user by Apollo user ID → `filters: { user_ids: ["<user_id>"] }` (can combine: `["current", "user_id_1"]`)
-- "team" / no user mention → omit filters entirely (returns team-wide data)
-- Filter by team/subteam → `filters: { team_ids: ["<subteam_id>"] }`
-- Filter by sequence name → first call `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_search` to resolve the name to an ID, then pass `filters: { emailer_campaign_ids: ["<id>"] }`
-
----
-
-### Sort
-
-If the user asks "who has the most...", "ranked by...", or "top reps by...", set:
-```
-sort: { metric: "<metric_name>", asc: false }
-```
-Use `asc: true` for "lowest first" or "worst performing" queries.
-
-Two constraints:
-- Sort only applies when `group_by` is set — it has no effect on flat queries
-- The sort metric must be included in the `metrics` array
-
----
-
-## Step 2 — Call the Analytics Tool
-
-Use `mcp__claude_ai_Apollo_MCP__apollo_analytics_sync_report` with the parameters determined above.
-
-If the question spans multiple independent dimensions (e.g. "show me email metrics by rep AND separately by sequence"), make two sequential calls.
-
-If the question is ambiguous, make a reasonable default call first, then offer to refine.
-
----
-
-## Step 3 — Present the Results
-
-**Flat response** (no group_by): Present as a clean two-column summary table — metric name and value.
-
-**Grouped response** (group_by only): Present as a table with the dimension as the first column and metrics as subsequent columns. Highlight notable outliers (top performer, lowest rate, biggest gap).
-
-**Pivot response** (group_by + pivot_group_by): Present each metric as a separate labeled table. Add a brief summary sentence per table.
+For pivots, present one table per metric.
 
 Always:
-- Convert decimals to readable percentages (e.g. `0.14` → `14%`)
-- Format large numbers with commas
-- If the response says "Showing first N of M rows", mention the total count and offer to refine
-- Add 1–2 sentences of insight after the data (e.g. "Tuesday has the highest call volume at 355 calls", "Sarah Flores leads reply rate at 14%")
 
----
+- format percentages clearly,
+- format large numbers with commas,
+- mention if only the first page or first N rows are shown,
+- add a short insight or caveat when useful.
 
-## Step 4 — Offer Follow-up Actions
+## Step 8 - Offer Read-Only Follow-Ups
 
-After presenting results, suggest 2–3 relevant next steps:
+Offer follow-ups like:
 
-1. **Drill deeper** — break down by another dimension (e.g. "want to see this by rep?")
-2. **Change date range** — compare with a different time period
-3. **Add more metrics** — "want to add meetings or tasks to this view?"
-4. **Pivot view** — "want to cross-tab this — e.g. by rep × sequence?"
-5. **Export** — format as CSV-style table for copy-paste
+1. change date range,
+2. break down by rep, sequence, account, or stage,
+3. add related metrics,
+4. export as a copyable table,
+5. sketch a dashboard layout for a Replit app using only aggregate data.
+
+Do not offer mutating next actions from this skill.
+
+## Optional Builder Guidance
+
+When the user is building a dashboard or another app, propose UI-ready KPI cards, trend lines, grouped tables, filters, and drilldowns that match the report. Use the analytics report for performance aggregates; when the user needs per-message or full contact detail, use the relevant read-only detail or search capability instead of treating this report as a raw export tool.

--- a/skills/enrich-lead/SKILL.md
+++ b/skills/enrich-lead/SKILL.md
@@ -1,80 +1,146 @@
 ---
 name: enrich-lead
-description: "Instant lead enrichment. Drop a name, company, LinkedIn URL, or email and get the full contact card with email, phone, title, company intel, and next actions."
+description: "Look up and add detail to a lead with Apollo, using search for disambiguation and explicit confirmation before spending credits."
 user-invocable: true
 argument-hint: [name, company, LinkedIn URL, or email]
 ---
 
 # Enrich Lead
 
-Turn any identifier into a full contact dossier. The user provides identifying info via "$ARGUMENTS".
+Turn an identifier into an Apollo contact profile. Search and disambiguation are allowed first. Credit-charging detail, private contact data, and contact creation require explicit approval.
+
+Act like a seller-facing GTM analyst. Resolve ambiguity, explain what is known versus still uncertain, and recommend the next safe action. Do not present raw API payloads, unnecessary internal IDs, or implementation fields in the contact card.
 
 ## Examples
 
-- `/apollo:enrich-lead Tim Zheng at Apollo`
-- `/apollo:enrich-lead https://www.linkedin.com/in/timzheng`
-- `/apollo:enrich-lead sarah@stripe.com`
-- `/apollo:enrich-lead Jane Smith, VP Engineering, Notion`
+In Replit, ask for the same workflow in natural language. The slash commands below are plugin command examples, not required Replit syntax.
+
+- `/apollo:enrich-lead Person Name at Example Company`
+- `/apollo:enrich-lead https://www.linkedin.com/in/example`
+- `/apollo:enrich-lead sarah@example.com`
+- `/apollo:enrich-lead Person Name, VP Engineering, Example Company`
 - `/apollo:enrich-lead CEO of Figma`
 
-## Step 1 — Parse Input
+Replit builder prompts:
 
-From "$ARGUMENTS", extract every identifier available:
-- First name, last name
-- Company name or domain
+- `I have signup emails in my Replit app. Match likely people first, show possible identities, then ask before enrichment.`
+- `Build an enrichment review queue for these emails so a seller can approve credit spend one lead at a time.`
+- `A product signup came in with only an email. Help me identify who it might be before charging credits.`
+
+## Step 0 - Confirm Available Tools
+
+Use the Apollo tools exposed by the current client. Tool names vary by client, so discover or confirm tools before relying on exact names.
+
+Needed capabilities:
+
+- people search for disambiguation, such as `apollo_mixed_people_api_search`
+- people match/enrichment, such as `apollo_people_match`
+- optional organization enrichment, such as `apollo_organizations_enrich`
+- optional contact create/update, such as `apollo_contacts_create` or `apollo_contacts_update`
+
+If credit-charging detail tools are unavailable, provide search-only candidates and explain what can still be done.
+
+## Step 1 - Parse Input
+
+Extract all identifiers available from "$ARGUMENTS":
+
+- first name and last name
+- company name or domain
 - LinkedIn URL
-- Email address
-- Job title (use as a matching hint)
+- email address
+- title or role hint
 
-If the input is ambiguous (e.g. just "CEO of Figma"), first use `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with relevant title and domain filters to identify the person, then proceed to enrichment.
+If the input is ambiguous, use people search to present up to 3 likely candidates. Ask the user which one to enrich.
 
-## Step 2 — Enrich the Person
+For a Replit enrichment review queue, present possible matches as UI-ready choices: display label, title, company, location, confidence note, and what enrichment would add after confirmation.
 
-> **Credit warning**: Tell the user enrichment consumes 1 Apollo credit before calling.
+For a batch of signup emails, build an enrichment review queue before spending credits. Group rows as exact-looking match, ambiguous match, and no clear match. Ask the user to approve either individual rows or the full reviewed count before enrichment:
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_people_match` with all available identifiers:
-- `first_name`, `last_name` if name is known
-- `domain` or `organization_name` if company is known
-- `linkedin_url` if LinkedIn is provided
-- `email` if email is provided
-- Set `reveal_personal_emails` to `true`
+```text
+This will enrich [N] people and consume up to [N] credits (1 credit per match, no charge for unmatched). Do you want to proceed?
+```
 
-If the match fails, try `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with looser filters and present the top 3 candidates. Ask the user to pick one, then re-enrich.
+## Step 2 - Ask Before Enrichment
 
-## Step 3 — Enrich Their Company
+Before calling a one-person match/enrichment tool, say this exact confirmation with the person's name or label:
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_organizations_enrich` with the person's company domain to pull firmographic context.
+```text
+Enriching [name] will consume 1 credit (no charge if not found). Do you want to proceed?
+```
 
-## Step 4 — Present the Contact Card
+Do not call enrichment until the user confirms.
 
-Format the output exactly like this:
+If the user declines, provide the best search-only summary available and offer to refine the search.
 
----
+## Step 3 - Enrich the Person
 
-**[Full Name]** | [Title]
-[Company Name] · [Industry] · [Employee Count] employees
+After approval, call the available people match/enrichment tool with the strongest identifiers:
+
+- LinkedIn URL, if available
+- email, if available
+- first name, last name, and company domain/name
+- title as a matching hint, if supported
+
+Before revealing phone number or direct-dial data, ask separately if the available tool says reveal consumes credits:
+
+```text
+Revealing phone or direct-dial data may consume credits for [N] people. Do you want to proceed?
+```
+
+Reveal personal emails or phone numbers only if the user approved the relevant contact-data enrichment or reveal action and the tool supports it.
+
+## Step 4 - Optional Company Context
+
+If organization enrichment appears credit-consuming, ask before calling it using the exact confirmation required by the available tool. For one company, say:
+
+```text
+Enriching [domain] will consume 1 credit (no charge if not found). Do you want to proceed?
+```
+
+If not approved or unavailable, use company context already returned by search/person enrichment.
+
+## Step 5 - Present the Contact Card
+
+Keep the output concise and avoid unnecessary raw payloads:
 
 | Field | Detail |
 |---|---|
-| Email (work) | ... |
-| Email (personal) | ... (if revealed) |
-| Phone (direct) | ... |
-| Phone (mobile) | ... |
-| Phone (corporate) | ... |
-| Location | City, State, Country |
-| LinkedIn | URL |
-| Company Domain | ... |
-| Company Revenue | Range |
-| Company Funding | Total raised |
-| Company HQ | Location |
+| Name | ... |
+| Title | ... |
+| Company | ... |
+| Location | ... |
+| Work email | ... |
+| Phone | ... |
+| LinkedIn | ... |
+| Company domain | ... |
+| Company size | ... |
+| Company revenue or funding | ... |
+| Company HQ | ... |
+| Notes | ... |
 
----
+Omit fields that are unavailable. Do not include internal IDs unless needed for a confirmed next action.
 
-## Step 5 — Offer Next Actions
+## Step 6 - Offer Gated Next Actions
 
-Ask the user which action to take:
+Offer available next actions:
 
-1. **Save to Apollo** — Create this person as a contact via `mcp__claude_ai_Apollo_MCP__apollo_contacts_create` with `run_dedupe: true`
-2. **Add to a sequence** — Ask which sequence, then run the sequence-load flow
-3. **Find colleagues** — Search for more people at the same company using `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with `q_organization_domains_list` set to this company
-4. **Find similar people** — Search for people with the same title/seniority at other companies
+1. Save to Apollo.
+2. Find colleagues at the same company.
+3. Find similar people.
+4. Add to a sequence through the sequencing workflow.
+5. Update contact or account fields after a separate write confirmation.
+6. Return a review-queue row shape for the user's Replit app without saving anything.
+
+Before saving to Apollo, say:
+
+```text
+This will create or update [N] Apollo contact record(s). Please confirm before I continue.
+```
+
+Before field-specific contact or account edits, say:
+
+```text
+This will update Apollo [object type] field(s): [specific fields and values]. Please confirm before I continue.
+```
+
+Approval to charge credits for more detail does not imply approval for saving or sequencing.

--- a/skills/inbound-website-visitors/SKILL.md
+++ b/skills/inbound-website-visitors/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: inbound-website-visitors
+description: "Set up Apollo website visitor tracking for a site, with safe tracker inspection, install-script retrieval, and gated updates."
+user-invocable: true
+argument-hint: [website or Replit app to configure]
+---
+
+# Inbound Website Visitors
+
+Help set up Apollo website visitor tracking, especially for a Replit-hosted website. Treat this as a tracker setup and install workflow, not a visitor analytics workflow, unless separate visitor analytics tools are discovered.
+
+This skill does not retrieve identified website visitors. If the user asks who visited, explain that the current setup tools configure tracking and direct them to the Apollo Website Visitors UI or a separate visitor analytics tool if one is discovered.
+
+## Examples
+
+In Replit, ask for the same workflow in natural language. The slash commands below are plugin command examples, not required Replit syntax.
+
+- `/apollo:inbound-website-visitors set up tracking on this Replit app`
+- `/apollo:inbound-website-visitors get the Apollo install script`
+- `/apollo:inbound-website-visitors add example.com as an allowed tracking domain`
+- `/apollo:inbound-website-visitors email the install script to my developer`
+
+Replit builder prompts:
+
+- `My tracking script is installed on a Replit app, but no visitors appear. Walk through deployment, domain, traffic timing, and script placement.`
+- `Help me add Apollo website visitor tracking to my Replit landing page, but do not change Apollo settings yet.`
+- `I am building a setup checklist for visitor tracking. Show what my app should verify before asking to update Apollo settings.`
+
+## Step 0 - Confirm Available Tools
+
+Use the Apollo tools exposed by the current client. Tool names vary by client and these tools may be feature-flagged.
+
+Expected capabilities:
+
+- tracker state lookup, such as `apollo_website_visitor_domain_tracker_index`
+- official install script retrieval, such as `apollo_website_visitor_domain_tracker_install_script`, if available in the current client
+- tracker update, such as `apollo_website_visitor_domain_tracker_update`
+- install email, such as `apollo_website_visitor_domain_tracker_send_install_email`
+
+If these tools are not available, explain that website visitor MCP support appears unavailable in this environment and may require deployment, OAuth scope, product feature, user permission, or the `mcp_integration` / `mcp_developers` feature gates.
+
+The separate install-script capability is conditional. It is not present in the checked-out local Leadgenie default-branch inventory, so prefer it when discovered but do not assume Replit can see it.
+
+## Step 1 - Inspect Tracker State
+
+The tracker lookup tool is not guaranteed to be read-only. In current Leadgenie source, `apollo_website_visitor_domain_tracker_index` is a find-or-create operation: if no tracker exists, it may create an empty team-scoped tracker.
+
+Before calling tracker lookup in a real Apollo account, say:
+
+```text
+This may create an empty Apollo website visitor tracker if one does not already exist. Please confirm before I inspect tracker state.
+```
+
+Call the tracker lookup tool only after that confirmation, or during an approved promptbook/test context where setup mutation is expected.
+
+Record only the information needed for setup:
+
+- whether a tracker exists,
+- tracker ID if needed for a confirmed action,
+- configured domains,
+- domain limit,
+- tracking status,
+- whether credits are exhausted,
+- whether contact-level tracking is enabled,
+- intent paths if available.
+
+Do not expose unnecessary raw payloads.
+
+## Step 2 - Fetch the Official Install Script
+
+If the install-script tool is available, use it to fetch:
+
+- app ID,
+- canonical script,
+- placement rules.
+
+Prefer the official install-script tool. Do not hand-assemble the tracking snippet when the official tool exists.
+
+If the install-script tool is not available, stop short of fabricating a tracking script. Explain that canonical script retrieval is unavailable in the current client, record the missing capability, and offer useful next steps: ask the user to paste the script from the Apollo Website Visitors UI, open Apollo to retrieve the official script themselves, or continue only with non-script placement guidance or a separately confirmed install-email flow if that outreach tool is visible.
+
+If no tracker exists or the tool returns a clear blocker, explain what is needed before installation can continue.
+
+## Step 3 - Help Install in Replit
+
+For a Replit app, inspect the local project files if available and identify where the script should go.
+
+Common placements:
+
+- HTML app: before `</head>` or as instructed by placement rules.
+- React/Vite/Next-style app: the main HTML shell or framework-specific head/script location.
+
+Only edit local project files when the user asks for implementation in that project. Do not change Apollo tracker settings during local code edits unless separately approved.
+
+For a Replit setup helper, present a checklist the app can show: deployed URL, custom domain if any, script placement, publish status, recent test traffic, configured tracker domains, and whether the next step is local code placement or an Apollo settings change.
+
+## Step 4 - Mutation Gate for Tracker Updates
+
+Before adding, editing, or deleting tracked domains or intent paths, say:
+
+```text
+This will update Apollo website visitor tracker settings. I will [specific change]. Please confirm before I continue.
+```
+
+Rules:
+
+- Strip protocol and path from domains before proposing an add.
+- Check domain limits when that data is available.
+- For intent paths, require paths to start with `/`, use human-readable labels, and keep the level tied to business intent such as pricing, demo, contact, or high-value product pages.
+- Warn the user if they are at or near the configured domain limit before adding a domain.
+- Use exact existing referrer IDs from tracker lookup for edit/delete.
+- Never guess referrer IDs.
+
+## Step 5 - Outreach Gate for Install Email
+
+Before sending an install email, first confirm the recipient and subject as non-send details. Then ask the exact outreach confirmation:
+
+```text
+This can affect real outreach or send a real email. I will send a real email with the Apollo install script to [recipient] with subject [subject]. Please confirm before I continue.
+```
+
+Do not send install email during smoke tests or without explicit confirmation.
+
+## Step 6 - Summarize Status
+
+Summarize:
+
+| Field | Value |
+|---|---|
+| Tracker available | ... |
+| Install script available | ... |
+| Configured domains | ... |
+| Local install target | ... |
+| Apollo settings changed | ... |
+| Email sent | ... |
+| Remaining blocker | ... |
+
+If the requested workflow cannot proceed because tools are missing, say whether the likely blocker is feature flag, permissions, deployment, OAuth scope, or client discovery.

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: onboarding
+description: "Use when a user is new to Apollo MCP, asks what Apollo can do, needs a safe first test, wants help choosing a GTM workflow, or is building an Apollo-powered app in Replit or another coding environment."
+user-invocable: true
+argument-hint: [question or workflow]
+---
+
+# Apollo MCP Onboarding
+
+Use this skill when the user is new to Apollo MCP, asks what Apollo MCP can do, wants help choosing a workflow, or wants a safe first connection test.
+
+The slash commands below are plugin command examples, not required Replit syntax.
+
+Examples:
+
+- `/apollo:onboarding what can Apollo MCP do?`
+- `/apollo:onboarding I am new to Apollo MCP`
+- `/apollo:onboarding help me choose between prospecting, enrichment, sequencing, analytics, and website visitors`
+- `/apollo:onboarding show safe first steps for testing this connection`
+
+Builder prompts, including Replit:
+
+- `What can I build with Apollo in Replit?`
+- `I want to build a lead finder. Which Apollo capabilities should I use first?`
+- `I am making a GTM dashboard in Replit. What can Apollo safely power?`
+- `I am building a Replit app that needs Apollo data. Do I need an Apollo API key?`
+- `Help me add Apollo website visitor tracking to a Replit app without changing anything yet.`
+
+## Core Behavior
+
+Start by discovering or confirming the Apollo tools visible in the current client. Tool names and generated suffixes vary by client, so describe capabilities instead of relying on exact tool names unless the current client exposes them.
+
+Use Replit-specific guidance only when the user mentions Replit, a Replit app, workspace skills, secrets, or building an app. Otherwise, keep the onboarding experience client-neutral.
+
+Act like a pragmatic GTM engineer, not an API wrapper. Keep the user focused on the business job, the safest next Apollo action, and what needs approval before riskier work. Avoid raw endpoint mechanics, internal IDs, tool payloads, and long setup questionnaires unless they are required for safety.
+
+Explain Apollo MCP in sales language:
+
+- People are Apollo database candidates found through search.
+- Contacts are saved records in the team's Apollo workspace.
+- Accounts or organizations are company records.
+- Sequences are outbound workflows; enrollment, approval, or activation can affect real outreach.
+- Website visitor tracker tools support setup and configuration; tracker lookup may create setup state.
+- Analytics tools are for read-only aggregate reporting.
+- Context Center tools, when visible, manage shared team AI context. Reads are safe with current-session IDs. Profile or product create/update actions can affect team-wide guidance and require explicit confirmation.
+
+Do not claim personalized "what's new since last time" behavior. This skill does not track `last_seen_version`.
+
+Do not claim the MCP can create or rotate Apollo API keys. If a builder needs an Apollo API key for app code, explain the path clearly:
+
+- The user must be an Apollo admin or have the required permission profile to create an API key.
+- Basic API access is available on Apollo plans, while advanced endpoints depend on the plan and the scopes selected for the key.
+- Create a named, least-privileged key in `Settings > Integrations > API Keys`; use a master key only when the required endpoint needs it.
+- Review the exact per-endpoint daily, hourly, and minute limits in the Apollo Developer Dashboard under Usage.
+- Store the key in the app's server-side secret store, such as Replit Secrets, and never expose it in frontend code, URLs, logs, or a repository.
+- For an app used by multiple Apollo customers, recommend an OAuth integration rather than sharing one person's API key.
+
+Link to [Create an API Key](https://docs.apollo.io/docs/create-api-key), [Apollo API FAQs](https://docs.apollo.io/docs/apollo-api-faqs), and [OAuth 2.0 for Partners](https://docs.apollo.io/docs/use-oauth-20-authorization-flow-to-access-apollo-user-information-partners) when the user needs implementation detail.
+
+## Safety Model
+
+Classify next steps before suggesting tool use:
+
+- Read-only: profile or user lookup, people search, contacts search, sequence search, aggregate analytics, and tool discovery.
+- Credit-consuming: people enrichment, company enrichment, credit-gated company search, phone reveal, or direct-dial reveal.
+- Setup/idempotent mutation-light: website visitor tracker lookup when it may create an empty tracker.
+- Mutating: contact create/update, account create/update, website visitor tracker update.
+- Outreach-risk: sequence enrollment, sequence remove/stop, sequence approval/activation, and website visitor install email.
+
+Never call credit-consuming, setup-side-effect, mutating, or outreach-risk tools from onboarding. If the user wants one of those actions, route them to the correct specialist skill and state the confirmation that will be required.
+
+Onboarding may call only tool discovery, profile/user lookup, or the smallest safe read-only smoke test when the user asks to test the connection.
+
+## Routing Menu
+
+When the user asks what to do, provide a compact menu:
+
+| Goal | Use | Safe first step | Approval needed |
+| --- | --- | --- | --- |
+| Build a lead finder | `prospect` | Search people with a small limit and table-friendly fields | Enrichment, phone reveal, contact save, sequencing |
+| Build an enrichment review queue | `enrich-lead` | Search possible matches and ask the user to choose | People/company enrichment, phone reveal, contact save |
+| Build a sequence prep UI | `sequence-load` | Search sequences and preview candidates | Enrichment, contact create/update, enrollment, activation |
+| Build a GTM dashboard | `analytics` | Aggregate report only | Do not mutate from analytics |
+| Build an Apollo-powered app | Onboarding/app setup guidance | Explain when to use the MCP vs an Apollo API key and how to store `APOLLO_API_KEY` in Replit Secrets | Creating, copying, rotating, or exposing API keys must happen outside the MCP |
+| Add visitor tracking to a Replit app | `inbound-website-visitors` | Check visible tracker tools and explain setup blockers | Tracker lookup, tracker update, install email |
+| Manage saved records, lists, tasks, or deals | Specialist skill not packaged in v1 | Search existing records first; use picker/dashboard framing from available tools | Contact/account/list/task/deal create, update, membership change, complete, skip, or delete-equivalent actions |
+| Inspect Context Center | Onboarding/safety guidance | Read profile/product context only when visible and ID is from the current session | Profile/product create or update affects shared team AI context |
+
+## Builder App Path (Including Replit)
+
+When a user is getting started in Replit or another coding environment, guide them through this path:
+
+1. Confirm the Apollo connector is visible and name which Apollo connector you are using.
+2. Run a safe profile/tool-discovery smoke test before any Apollo data workflow.
+3. Help the user choose one buildable app workflow: lead finder, enrichment review queue, GTM dashboard, sequence prep UI, contact/list picker, task/deal dashboard, or visitor tracking setup.
+4. Map the first UI screen to safe fields and table/card shapes without raw emails, phones, internal IDs, or payload dumps.
+5. If the app will call Apollo directly from code, explain that the user needs an Apollo API key from Apollo account settings, should save it in Replit Secrets as `APOLLO_API_KEY`, and should call Apollo from backend/server code instead of exposing the key in frontend code.
+6. Offer gated next actions: enrichment, save/update, tracker setup/update, list membership, sequence enrollment, activation, or email send only after explicit confirmation for that exact action.
+
+If the user goal is ambiguous, ask for:
+
+- desired outcome,
+- target audience or account criteria,
+- volume,
+- whether the run must stay read-only,
+- whether they are willing to spend Apollo credits,
+- whether they intend to save records, enroll contacts, send email, or activate sequences.
+
+## Safe Connection Test
+
+For a first test, use this sequence:
+
+1. List Apollo MCP tools visible in the current client.
+2. Group tools by read-only, credit-consuming, setup/idempotent mutation-light, mutating, outreach-risk, website visitor, and unknown.
+3. If available, run profile or user lookup.
+4. If the user approves a read-only smoke test, run one small people search or contacts search with the smallest useful limit.
+5. Stop before enrichment, reveal, create, update, enroll, activate, approve, remove/stop, tracker lookup, tracker update, or install email.
+
+Report results as:
+
+- connection status,
+- visible Apollo capabilities,
+- safe next recommended specialist skill,
+- buildable Replit workflows such as lead finder, enrichment review queue, GTM dashboard, sequence prep UI, contact/list picker, or visitor tracking setup,
+- note when a workflow is supported by visible tool metadata but not yet covered by a dedicated v1 skill,
+- blocked or missing capabilities,
+- whether the user's Replit app needs an Apollo API key and the safe storage pattern if it does,
+- no private emails, phone numbers, or Apollo internal IDs copied.

--- a/skills/prospect/SKILL.md
+++ b/skills/prospect/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: prospect
-description: "Full ICP-to-leads pipeline. Describe your ideal customer in plain English and get a ranked table of enriched decision-maker leads with emails and phone numbers."
+description: "Find prospects from an ICP using Apollo search first, with credit-spending steps and record saves only after explicit approval."
 user-invocable: true
 argument-hint: [describe your ideal customer]
 ---
 
 # Prospect
 
-Go from an ICP description to a ranked, enriched lead list in one shot. The user describes their ideal customer via "$ARGUMENTS".
+Turn an ICP description into a ranked prospect shortlist. Default to search-only results. Do not charge credits, show private contact data, save records, or sequence anyone unless the user explicitly approves that separate step.
+
+Operate like a GTM engineer helping a seller build a usable prospecting motion. Make one concise, correctable assumption when the user's ICP is underspecified and a safe read-only search can still proceed. Do not expose raw tool names, endpoint details, internal IDs, or private contact fields in seller-facing output unless a confirmed next action requires them.
 
 ## Examples
+
+In Replit, ask for the same workflow in natural language. The slash commands below are plugin command examples, not required Replit syntax.
 
 - `/apollo:prospect VP of Engineering at Series B+ SaaS companies in the US, 200-1000 employees`
 - `/apollo:prospect heads of marketing at e-commerce companies in Europe`
@@ -17,74 +21,126 @@ Go from an ICP description to a ranked, enriched lead list in one shot. The user
 - `/apollo:prospect procurement managers at manufacturing companies with 1000+ employees`
 - `/apollo:prospect SDR leaders at companies using Salesforce and Outreach`
 
-## Step 1 — Parse the ICP
+Replit builder prompts:
 
-Extract structured filters from the natural language description in "$ARGUMENTS":
+- `I am building a Replit lead finder. Given form inputs for title, industry, headcount, and geography, design the Apollo search flow and result table.`
+- `Find VP Engineering prospects at Series B fintech companies in the US, but start search-only with 10 results.`
+- `My app has an ICP form for steel manufacturing companies. Help me turn the inputs into an Apollo search without saving anything.`
 
-**Company filters:**
-- Industry/vertical keywords → `q_organization_keyword_tags`
-- Employee count ranges → `organization_num_employees_ranges`
-- Company locations → `organization_locations`
-- Specific domains → `q_organization_domains_list`
+## Step 0 - Confirm Available Tools
 
-**Person filters:**
-- Job titles → `person_titles`
-- Seniority levels → `person_seniorities`
-- Person locations → `person_locations`
+Use the Apollo tools exposed by the current client. Tool names vary by client, so discover or confirm tools before relying on exact names.
 
-If the ICP is vague, ask 1-2 clarifying questions before proceeding. At minimum, you need a title/role and an industry or company size.
+Needed capabilities:
 
-## Step 2 — Search for Companies
+- people search, such as `apollo_mixed_people_api_search`
+- optional company search, such as `apollo_mixed_companies_search`
+- optional people enrichment/match, such as `apollo_people_match` or `apollo_people_bulk_match`
+- optional contact creation, such as `apollo_contacts_create`
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_mixed_companies_search` with the company filters:
-- `q_organization_keyword_tags` for industry/vertical
-- `organization_num_employees_ranges` for size
-- `organization_locations` for geography
-- Set `per_page` to 25
+If a needed capability is missing, explain what is unavailable and continue only with safe alternatives.
 
-## Step 3 — Enrich Top Companies
+## Step 1 - Parse the ICP
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_organizations_bulk_enrich` with the domains from the top 10 results. This reveals revenue, funding, headcount, and firmographic data to help rank companies.
+Extract structured filters from "$ARGUMENTS":
 
-## Step 4 — Find Decision Makers
+Company filters:
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with:
-- `person_titles` and `person_seniorities` from the ICP
-- `q_organization_domains_list` scoped to the enriched company domains
-- `per_page` set to 25
+- industry or vertical keywords, usually `q_organization_keyword_tags` when supported
+- employee count ranges, usually `organization_num_employees_ranges`
+- company locations, usually `organization_locations`
+- company domains, usually `q_organization_domains_list`
+- technologies or funding signals, if supported by the exposed tools
 
-## Step 5 — Enrich Top Leads
+Person filters:
 
-> **Credit warning**: Tell the user exactly how many credits will be consumed before proceeding.
+- job titles, usually `person_titles`
+- seniority levels, usually `person_seniorities`
+- person locations, usually `person_locations`
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_people_bulk_match` to enrich up to 10 leads per call with:
-- `first_name`, `last_name`, `domain` for each person
-- `reveal_personal_emails` set to `true`
+If the ICP includes a role/title plus one company, geography, domain, industry, size, or funding signal, proceed with one concise, correctable assumption instead of turning the interaction into a questionnaire. If neither a role/title nor a company/account signal is present, ask one clarifying question before searching.
 
-If more than 10 leads, batch into multiple calls.
+## Step 2 - Search Read-Only
 
-## Step 6 — Present the Lead Table
+Run people search first with a small, appropriate limit. Use the user's requested volume when reasonable; otherwise default to 10.
 
-Show results in a ranked table:
+Use company search only if it is available and safe in the current environment. Treat Apollo company search as credit-consuming, non-mutating search when the current tool description or source-derived risk matrix indicates one-credit search behavior; do not treat approval for company search as approval to mutate accounts or contacts. If company search is credit-gated or unclear, ask before using it:
 
-### Leads matching: [ICP Summary]
+```text
+This company search may consume 1 credit. Do you want to proceed?
+```
 
-| # | Name | Title | Company | Employees | Revenue | Email | Phone | ICP Fit |
-|---|---|---|---|---|---|---|---|---|
+Do not call credit-charging enrichment tools during this step.
 
-**ICP Fit** scoring:
-- **Strong** — title, seniority, company size, and industry all match
-- **Good** — 3 of 4 criteria match
-- **Partial** — 2 of 4 criteria match
+## Step 3 - Present a Search-Only Shortlist
 
-**Summary**: Found X leads across Y companies. Z credits consumed.
+Show a concise table without private emails, phones, or unnecessary internal IDs:
 
-## Step 7 — Offer Next Actions
+| # | Name or masked name | Title | Company | Location | Fit |
+|---|---|---|---|---|---|
 
-Ask the user:
+Fit scoring:
 
-1. **Save all to Apollo** — Bulk-create contacts via `mcp__claude_ai_Apollo_MCP__apollo_contacts_create` with `run_dedupe: true` for each lead
-2. **Load into a sequence** — Ask which sequence and run the sequence-load flow for these contacts
-3. **Deep-dive a company** — Run `/apollo:company-intel` on any company from the list
-4. **Refine the search** — Adjust filters and re-run
-5. **Export** — Format leads as a CSV-style table for easy copy-paste
+- Strong: title, seniority, company type, and location/size match
+- Good: most major criteria match
+- Partial: useful but missing one or more key criteria
+
+Summarize:
+
+- number of prospects reviewed
+- filters used
+- whether results are search-only or include any credit-charged details
+- UI-friendly fields for a Replit lead finder, such as display name, title, company, location, fit reason, and next-safe-action
+- recommended safe next step, such as refine filters, add more detail for selected prospects, save selected contacts, or prepare for sequencing
+
+## Step 4 - Offer Gated Next Actions
+
+Offer only actions that are available in the current client:
+
+1. Refine the search with different filters.
+2. Add more detail for selected prospects after credit confirmation.
+3. Save selected prospects to Apollo after mutation confirmation.
+4. Load selected contacts into a sequence by switching to the sequencing workflow.
+5. Format the search-only shortlist as a copyable table if the user wants to work from it manually.
+
+Before bulk people enrichment, say this exact confirmation with the real count:
+
+```text
+This will enrich [N] people and consume up to [N] credits (1 credit per match, no charge for unmatched). Do you want to proceed?
+```
+
+For one-person enrichment, say this exact confirmation with the person's name or label:
+
+```text
+Enriching [name] will consume 1 credit (no charge if not found). Do you want to proceed?
+```
+
+For company enrichment, use the exact company enrichment confirmation required by the available tool.
+
+Before phone number or direct-dial reveal, say:
+
+```text
+Revealing phone or direct-dial data may consume credits for [N] people. Do you want to proceed?
+```
+
+If the user asks for both bulk enrichment and phone/direct-dial data, ask the bulk enrichment confirmation and the phone/direct-dial confirmation as two separate exact confirmations. Do not merge the phone/direct-dial confirmation into an addendum or paraphrase.
+
+Before contact creation, say:
+
+```text
+This will create or update [N] Apollo contact record(s). Please confirm before I continue.
+```
+
+Before account creation or account update, say:
+
+```text
+This will create or update [N] Apollo account record(s). Please confirm before I continue.
+```
+
+Before field-specific account edits, say:
+
+```text
+This will update Apollo [object type] field(s): [specific fields and values]. Please confirm before I continue.
+```
+
+Approval to charge credits for more detail does not imply approval for contact creation or sequencing.

--- a/skills/sequence-load/SKILL.md
+++ b/skills/sequence-load/SKILL.md
@@ -1,120 +1,180 @@
 ---
 name: sequence-load
-description: "Find leads matching criteria and bulk-add them to an Apollo outreach sequence. Handles enrichment, contact creation, deduplication, and enrollment in one flow."
+description: "Prepare contacts for an Apollo sequence with separate approvals for enrichment, contact creation, enrollment, and activation."
 user-invocable: true
 argument-hint: [targeting criteria + sequence name]
 ---
 
 # Sequence Load
 
-Find, enrich, and load contacts into an outreach sequence — end to end. The user provides targeting criteria and a sequence name via "$ARGUMENTS".
+Help prepare contacts for an Apollo sequence. This workflow must be staged. Do not enrich, create contacts, enroll contacts, approve sequences, activate sequences, or send outreach without explicit approval for that exact step.
+
+Operate like a careful outbound operator, not a raw API wrapper. Keep sequence building, contact enrollment, sequence activation, and direct message sending separate. If a tool is not visible in the current client, do not imply that action is available.
 
 ## Examples
 
+In Replit, ask for the same workflow in natural language. The slash commands below are plugin command examples, not required Replit syntax.
+
 - `/apollo:sequence-load add 20 VP Sales at SaaS companies to my "Q1 Outbound" sequence`
-- `/apollo:sequence-load SDR managers at fintech startups → Cold Outreach v2`
-- `/apollo:sequence-load list sequences` (shows all available sequences)
-- `/apollo:sequence-load directors of engineering, 500+ employees, US → Demo Follow-up`
+- `/apollo:sequence-load SDR managers at fintech startups -> Cold Outreach v2`
+- `/apollo:sequence-load list sequences`
+- `/apollo:sequence-load directors of engineering, 500+ employees, US -> Demo Follow-up`
 - `/apollo:sequence-load reload 15 more leads into "Enterprise Pipeline"`
 
-## Step 1 — Parse Input
+Replit builder prompts:
 
-From "$ARGUMENTS", extract:
+- `I want to enroll USA-based steel manufacturing companies into an outbound sequence. Help me build the safe approval flow first.`
+- `Create a sequence prep UI for selected leads before saving contacts and enrolling them.`
+- `My Replit app has a shortlist of prospects. Show the staged checklist before enrichment, contact save, enrollment, and activation.`
 
-**Targeting criteria:**
-- Job titles → `person_titles`
-- Seniority levels → `person_seniorities`
-- Industry keywords → `q_organization_keyword_tags`
-- Company size → `organization_num_employees_ranges`
-- Locations → `person_locations` or `organization_locations`
+## Step 0 - Confirm Available Tools
 
-**Sequence info:**
-- Sequence name (text after "to", "into", or "→")
-- Volume — how many contacts to add (default: 10 if not specified)
+Use the Apollo tools exposed by the current client. Tool names vary by client, especially sequence add/remove tools with generated suffixes.
 
-If the user just says "list sequences", skip to Step 2 and show all available sequences.
+When using sequence search, follow the parameter types exposed by the current client for `page` and `per_page`. Some clients expose numeric paging semantics as string-typed schema fields. Use small values such as page 1 and per_page 1, and if the client or server rejects paging because of a schema mismatch, stop and report a `tool/schema` blocker instead of retrying blindly with larger pages or unsafe fallbacks.
 
-## Step 2 — Find the Sequence
+Needed capabilities:
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_search` to find the target sequence:
-- Set `q_name` to the sequence name from input
+- sequence search, such as `apollo_emailer_campaigns_search`
+- email account lookup, such as `apollo_email_accounts_index`
+- people search, such as `apollo_mixed_people_api_search`
+- optional people enrichment, such as `apollo_people_bulk_match`
+- optional contact create/update, such as `apollo_contacts_create`
+- optional sequence create/update tools
+- optional add contacts to sequence
+- optional sequence approval/activation
+- optional remove or stop contacts from sequence
+- optional direct message draft/send tools
 
-If no match or multiple matches:
-- Show all available sequences in a table: | Name | ID | Status |
-- Ask the user to pick one
+If a required tool is unavailable, stop before the missing step and explain the blocker.
 
-## Step 3 — Get Email Account
+## Step 1 - Parse Input
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_email_accounts_index` to list linked email accounts.
+Extract:
 
-- If one account → use automatically
-- If multiple → show them and ask which to send from
+- targeting criteria
+- sequence name
+- requested volume, defaulting to 10
+- whether the user only wants to list sequences
 
-## Step 4 — Find Matching People
+If the request is just to list sequences, run sequence search only and stop.
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with the targeting criteria.
-- Set `per_page` to the requested volume (or 10 by default)
+If the user is building a Replit sequence prep UI, structure the answer as staged screens or checklist steps: candidate review, enrichment approval, contact save approval, sequence selection, sending account selection, enrollment confirmation, and separate activation confirmation.
 
-Present the candidates in a preview table:
+## Step 2 - Resolve Sequence and Sending Account
 
-| # | Name | Title | Company | Location |
-|---|---|---|---|---|
+Use read-only tools to:
 
-Ask: **"Add these [N] contacts to [Sequence Name]? This will consume [N] Apollo credits for enrichment."**
+- find the sequence by name,
+- list candidate sequences if there are zero or multiple matches,
+- list available email accounts if enrollment is eventually requested.
 
-Wait for confirmation before proceeding.
+If exactly one sending account is visible, use it as the default in previews. If multiple are visible, ask the user which sending account to use before any enrollment confirmation.
 
-## Step 5 — Enrich and Create Contacts
+Do not enroll or activate anything in this step.
 
-For each approved lead:
+## Step 3 - Search and Preview Candidates
 
-1. **Enrich** — Use `mcp__claude_ai_Apollo_MCP__apollo_people_bulk_match` (batch up to 10 per call) with:
-   - `first_name`, `last_name`, `domain` for each person
-   - `reveal_personal_emails` set to `true`
+Use people search with the targeting criteria and requested volume.
 
-2. **Create contacts** — For each enriched person, use `mcp__claude_ai_Apollo_MCP__apollo_contacts_create` with:
-   - `first_name`, `last_name`, `email`, `title`, `organization_name`
-   - `direct_phone` or `mobile_phone` if available
-   - `run_dedupe` set to `true`
+Present a preview table without private emails or phones:
 
-Collect all created contact IDs.
+| # | Name or masked name | Title | Company | Location | Fit |
+|---|---|---|---|---|---|
 
-## Step 6 — Add to Sequence
+Then ask whether the user wants to continue to enrichment.
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_add_contact_ids` with:
-- `id`: the sequence ID
-- `emailer_campaign_id`: same sequence ID
-- `contact_ids`: array of created contact IDs
-- `send_email_from_email_account_id`: the chosen email account ID
-- `sequence_active_in_other_campaigns`: `false` (safe default)
+## Step 4 - Credit Gate for Enrichment
 
-## Step 7 — Confirm Enrollment
+Before bulk people enrichment, say this exact confirmation with the real count:
 
-Show a summary:
+```text
+This will enrich [N] people and consume up to [N] credits (1 credit per match, no charge for unmatched). Do you want to proceed?
+```
 
----
+Do not enrich until the user confirms.
 
-**Sequence loaded successfully**
+## Step 5 - Mutation Gate for Contact Creation
+
+After enrichment, preview the contacts that would be created or updated.
+
+Before contact creation, say:
+
+```text
+This will create or update [N] Apollo contact record(s). Please confirm before I continue.
+```
+
+Do not create or update contacts until the user confirms.
+
+## Step 6 - Outreach Gate for Sequence Enrollment
+
+After contacts exist, preview:
+
+- sequence name,
+- contact count,
+- sending account,
+- whether the sequence is active or may send automatically.
+- UI confirmation copy that separates enrollment from activation.
+
+Before adding contacts to a sequence, say:
+
+```text
+This can affect real outreach or send a real email. I will add [N] contact(s) to [Sequence Name] using [sending account]. Please confirm before I continue.
+```
+
+If an add-contacts-to-sequence tool is visible in the current client, do not hard-decline enrollment as unavailable. Stop before the tool call and ask the exact confirmation above. If the add tool is not visible, record that as a missing capability and do not attempt a fallback.
+
+When enrollment is approved and the visible tool supports these fields, use the resolved sequence ID for the campaign ID, resolved contact IDs from the current session, the confirmed sending account ID, and a conservative default such as `sequence_active_in_other_campaigns: false`.
+
+Do not enroll until the user confirms.
+
+## Step 7 - Separate Gate for Activation or Approval
+
+If the user asks to approve, activate, or otherwise start sequence sending, ask separately:
+
+```text
+This can enable outbound sending. Please confirm that you want to approve or activate [Sequence Name].
+```
+
+Approval to enroll contacts does not imply approval to activate or approve a sequence.
+
+If sequence create or update tools are visible and the user asks to build or edit a sequence, confirm the sequence name, audience, goal, and message-review status before any create or update call. Sequence creation or editing does not imply permission to enroll contacts or activate sending.
+
+## Step 8 - Separate Gate for Remove or Stop
+
+If the user asks to remove, pause, stop, or otherwise change existing sequence membership, preview:
+
+- contact count,
+- sequence name,
+- sequence ID resolved from this session,
+- exact contact IDs resolved from this session,
+- requested mode such as remove, stop, pause, or finish,
+- whether active outreach state may change.
+
+Before removing or stopping contacts in a sequence, say:
+
+```text
+This will change live sequence membership or sending state for [N] contact(s) in [Sequence Name] ([Sequence ID]) using mode [mode] for contact IDs [contact IDs]. Please confirm before I continue.
+```
+
+Approval to enroll contacts does not imply approval to remove, stop, pause, or finish contacts in a sequence.
+
+## Step 9 - Direct Message Boundary
+
+If direct email/message draft or send tools are visible, keep draft creation separate from sending. Creating a draft is not the same as sending. Before any send-now action, confirm recipient, subject, body, and sending mailbox, and state that it sends a real email. Do not send from an inferred or guessed mailbox ID.
+
+## Step 10 - Summarize Results
+
+After any confirmed action, summarize:
 
 | Field | Value |
 |---|---|
-| Sequence | [Name] |
-| Contacts added | [count] |
-| Sending from | [email address] |
-| Credits used | [count] |
+| Sequence | ... |
+| Contacts searched | ... |
+| Contacts enriched | ... |
+| Contacts created/updated | ... |
+| Contacts enrolled | ... |
+| Sending account | ... |
+| Credits used or expected | ... |
 
-**Contacts enrolled:**
-
-| Name | Title | Company | Email |
-|---|---|---|---|
-
----
-
-## Step 8 — Offer Next Actions
-
-Ask the user:
-
-1. **Load more** — Find and add another batch of leads
-2. **Review sequence** — Show sequence details and all enrolled contacts
-3. **Remove a contact** — Use `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_remove_or_stop_contact_ids` to remove specific contacts
-4. **Pause a contact** — Re-add with `status: "paused"` and an `auto_unpause_at` date
+Report skipped steps clearly.


### PR DESCRIPTION
## Summary

Improves Apollo workflow skills and the public documentation for the Apollo MCP plugin across Claude Code, Cowork, and Cursor.

- Adds onboarding and inbound website visitor workflows.
- Updates prospecting, enrichment, sequencing, and analytics guidance with clearer approval gates and seller-facing outputs.
- Adds official Apollo API-key and OAuth guidance for builders who need to call Apollo directly from their application.
- Refreshes the README with a client-neutral title, supported workflows, separate Claude Code/Cowork/Cursor installation instructions, authentication, and safety guidance.

## Scope

This PR changes plugin skill guidance and public documentation only.

It does not add MCP tools or API endpoints, modify hosted MCP tool descriptions, include local tunnel or credential material, or include evaluation transcripts.

The repository includes reusable workflow skill files, but this PR does not claim that every MCP client automatically installs or invokes them. Replit skill distribution is intentionally outside this PR while Apollo confirms the supported partner delivery path with Replit.

## Validation

- Validated all six `SKILL.md` files and their manifests locally.
- Checked the seven-file PR diff for whitespace errors.
- Rebased the branch onto current `main` and verified that Cursor installation guidance remains present.
