### PR TITLE
Publish portable Apollo skills 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "url": "https://www.apollo.io/"
   },
   "metadata": {
-    "description": "Official Apollo.io plugin marketplace for Claude"
+    "description": "Official Apollo.io skills and MCP plugin marketplace for Claude"
   },
   "plugins": [
     {
       "name": "apollo",
-      "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics — one-click Apollo MCP server integration for Claude Code and Cowork.",
+      "description": "Apollo onboarding and portable sales workflows for Claude Code and Cowork.",
       "source": "./",
       "homepage": "https://www.apollo.io/"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
-  "version": "0.1.1",
-  "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics with Apollo.io — one-click MCP server integration for Claude Code and Cowork.",
+  "version": "0.3.0",
+  "description": "Onboard, prospect, enrich leads, manage sequences, and query analytics with Apollo MCP for Claude Code and Cowork.",
   "author": {
     "name": "Apollo.io",
     "url": "https://www.apollo.io/"
@@ -9,5 +9,5 @@
   "repository": "https://github.com/apolloio/apollo-mcp-plugin",
   "homepage": "https://www.apollo.io/",
   "license": "MIT",
-  "keywords": ["apollo", "sales", "prospecting", "icp", "enrichment", "sequences", "analytics", "mcp"]
+  "keywords": ["apollo", "sales", "onboarding", "prospecting", "icp", "enrichment", "sequences", "analytics", "mcp"]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
-  "version": "0.1.1",
-  "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics with Apollo.io — one-click MCP server integration.",
+  "version": "0.3.0",
+  "description": "Onboard, prospect, enrich leads, manage sequences, and query analytics with Apollo MCP.",
   "author": {
     "name": "Apollo.io",
     "email": "devtools@apollo.io"
@@ -9,6 +9,6 @@
   "homepage": "https://www.apollo.io/",
   "repository": "https://github.com/apolloio/apollo-mcp-plugin",
   "license": "MIT",
-  "keywords": ["apollo", "sales", "prospecting", "icp", "enrichment", "sequences", "analytics", "mcp"],
+  "keywords": ["apollo", "sales", "onboarding", "prospecting", "icp", "enrichment", "sequences", "analytics", "mcp"],
   "mcpServers": "./.mcp.json"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate skills and packages
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm build
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+dist/
+node_modules/
 Thumbs.db
 Desktop.ini
 ._*

--- a/README.md
+++ b/README.md
@@ -1,163 +1,83 @@
-# Apollo Plugin for Claude Code and Cowork
+# Apollo Agent Skills and MCP Plugins
 
-Prospect, enrich leads, and add to outreach sequences with [Apollo.io](https://www.apollo.io/) MCP Server
-- Fast to install.
-- Powerful in execution.
-- Designed for real GTM workflows.
+Portable sales workflows for the [Apollo MCP server](https://docs.apollo.io/docs/apollo-mcp), packaged for Claude, Cursor, Codex, GitHub Copilot, and generic Agent Skills clients.
 
----
+This repository is the canonical public source. Edit each workflow only in `skills/<skill>/SKILL.md`; package builds copy those canonical directories without client-specific rewrites.
 
-## 🔌 One-Click MCP Server Integration
+## Public Skills
 
-This plugin automatically configures the Apollo MCP Server when installed.
-No manual server setup or config files.
-Install the plugin, authenticate with Apollo, and run `/apollo:*` commands.
+| Skill | What it does | Safety behavior |
+|---|---|---|
+| `onboarding` | Connect with OAuth, verify access, and choose a workflow | Read-only verification |
+| `analytics` | Answer sales performance questions | Read-only |
+| `enrich-lead` | Enrich a person and their company | Confirms each credit action |
+| `prospect` | Turn an ICP into a ranked lead list | Confirms full enrichment volume and balance |
+| `sequence-load` | Find and enroll contacts into a sequence | Previews and confirms credit use and enrollment |
 
----
+The machine-readable source for versions, tool dependencies, safety behavior, and supported clients is [`catalog/skills.yaml`](catalog/skills.yaml).
 
-## ✅ Powerful Skills
+## Install
 
-High-value skills that chain multiple Apollo APIs into complete workflows:
+### Consent-Based Installer
 
-| Skill | What it does |
-|---|---|
-| `/apollo:enrich-lead` | Drop a name, LinkedIn URL, or email and get a full contact card with company context and next actions |
-| `/apollo:prospect` | Describe your ICP in plain English and get a ranked table of enriched decision-makers |
-| `/apollo:sequence-load` | Find leads, enrich them, dedupe, and bulk-add them to an Apollo sequence with a preview before enrollment |
-| `/apollo:analytics` | Ask any sales performance question and get formatted tables from real Apollo analytics data |
+From a checkout:
 
-
-### `/apollo:enrich-lead`
-
-Best for: one-off enrichment and fast lead lookups. <br>
-Input: name, company, LinkedIn URL, or email <br>
-Output: enriched profile (role, location, company context) and suggested next steps
-
-### `/apollo:prospect`
-Best for: turning an ICP into a shortlist fast. <br>
-Input: ICP description (industry, size, geography, titles) <br>
-Output: ranked lead table with enriched decision-makers
-
-### `/apollo:sequence-load`
-Best for: taking action on a list. <br>
-Input: targeting criteria + target sequence <br>
-Output: preview of candidates, enrichment + dedupe, then bulk enrollment into the sequence
-
-### `/apollo:analytics`
-Best for: answering performance questions without opening a dashboard. <br>
-Input: any question about emails, calls, meetings, tasks, opportunities, sequences, or conversation intelligence <br>
-Output: formatted tables with real Apollo data, broken down by rep, team, time, sequence, stage, or any other dimension
-
-
-Important: sequence enrollment may trigger outbound depending on your sequence settings and sending configuration.
-
----
-
-## 🧠 Model Recommendations (Quality-First)
-
-Recommended: Opus (best quality)
-
-Use Opus when you want the strongest reasoning and the most reliable multi-step tool orchestration.
-
-- Best for: prospecting workflows, ambiguous matches, multi-step chaining, and anything high-stakes
-- Tradeoff: higher latency and higher model usage cost on the Anthropic side
-
-### Strong fallback: Sonnet (faster)
-
-Use Sonnet when you want speed for quick lookups, smaller jobs, or rapid iteration.
-
-- Best for: quick searches, lightweight enrichment, and tight loops
-- Tradeoff: may require more user guidance for complex multi-step workflows
-
-In Claude Code, you can switch models via `/model`.
-
-
----
-
-## 📦 Installation
-
-### Cowork
-
-Click the link below to install in one step:
-
-[Install in Cowork](https://claude.ai/desktop/customize/plugins/new?marketplace=apolloio/apollo-mcp-plugin&plugin=apollo)
-
-Then restart Cowork to ensure the MCP server starts correctly.
-
-### Claude Code
-
-#### 1. Add this plugin's marketplace
-
-In Claude Code, run:
-
+```bash
+pnpm install
+pnpm exec apollo-skills setup
+pnpm exec apollo-skills list
+pnpm exec apollo-skills recommend "find decision makers matching my ICP"
+pnpm exec apollo-skills add prospect --target generic
+pnpm exec apollo-skills doctor
 ```
+
+After publication, use `npx @apolloio/agent-skills` in place of `pnpm exec apollo-skills`.
+
+`setup` installs only the onboarding skill. `setup` and `add` show the selected skills, destination, version, credit behavior, and write behavior before asking for confirmation. Use `--yes` only after reviewing that plan.
+
+Supported targets are `generic`, `claude`, `cursor`, `codex`, and `copilot`.
+
+### Claude Code and Cowork
+
+```text
 /plugin marketplace add apolloio/apollo-mcp-plugin
-```
-
-#### 2. Install the plugin
-
-```
 /plugin install apollo@apollo-plugin-marketplace
 ```
 
-#### 3. Restart Claude Code
-
-This ensures the MCP server starts correctly.
+[Install in Cowork](https://claude.ai/desktop/customize/plugins/new?marketplace=apolloio/apollo-mcp-plugin&plugin=apollo)
 
 ### Cursor
 
-1. Open Cursor and go to the Plugin Marketplace
-2. Search for "Apollo" and install
-3. Authenticate with your Apollo.io account when prompted
+Open the Cursor Plugin Marketplace, search for `Apollo`, and install the plugin.
 
----
+## Connect Apollo MCP
 
-## 🔑 Authentication
+Every package uses the same remote Streamable HTTP endpoint:
 
-The Apollo MCP Server supports **OAuth**:
+```text
+https://mcp.apollo.io/mcp
+```
 
-1. After installation, run `/mcp` in Claude Code or `connect` to Apollo.io connector from settings
-2. Select the **Apollo** server and click **Authenticate**
-3. Complete the Apollo.io login in your browser
-4. Done — all commands are now ready to use
+Authentication uses OAuth 2.0. Apollo permissions, plan limits, and credits continue to apply. Follow the [Apollo MCP documentation](https://docs.apollo.io/docs/apollo-mcp) for client-specific connection controls.
 
----
+## Recommend Contract
 
-## **⚠️** Apollo Credits and Safety
+[`contracts/recommend-apollo-skills.schema.json`](contracts/recommend-apollo-skills.schema.json) defines the read-only `recommend_apollo_skills` contract. Contract version `1.0.0` returns recommendations and client-specific install commands; it never installs files.
 
-Some operations consume Apollo credits:
+## Maintain
 
-- People enrichment typically costs 1 credit per person
-- Bulk enrichment consumes credits based on how many people are enriched
+```bash
+pnpm install
+pnpm check
+pnpm build
+```
 
-This plugin is designed to warn and request confirmation before credit-consuming actions by default.
-
-Sequence safety:
-
-- Adding contacts to a sequence can enroll them into an active sequence
-- Depending on your sequence settings, outbound may start automatically
-- Always verify your sequence name, sending account, and enrollment volume before confirming
-
----
-
-## Quickstart Examples
-
-Try these in Claude:
-
-- “Enrich this lead: [https://www.linkedin.com/in/…”](https://www.linkedin.com/in/%E2%80%A6%E2%80%9D)
-- “Find 25 VP Sales at SaaS companies (200-1000 employees) that raised funding in the last 6 months.”
-- “Load the top 10 enriched leads into my sequence called ‘Q1 Enterprise Outbound’ and show me a preview before enrolling.”
-- “Show me email and call performance by rep for this quarter, sorted by calls made.”
-
----
-
-## 🙌 Credits
-
-- **MCP Server** by [Apollo.io](https://docs.apollo.io/)
-- **Plugin Specification** by [Anthropic](https://docs.anthropic.com/)
-
----
+- Keep public skill source under `skills/`.
+- Update the catalog and focused eval cases with behavioral changes.
+- Use stable Apollo server-level tool names, not client-qualified names.
+- Keep generated output under `dist/`; it is not committed.
+- Keep private, local, transport-experiment, raw evaluation, and credential-handling artifacts out of this repository.
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT. See [LICENSE](LICENSE).

--- a/bin/apollo-skills.mjs
+++ b/bin/apollo-skills.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { createInterface } from "node:readline/promises";
+import process from "node:process";
+import { loadCatalog, recommendSkills } from "../lib/catalog.mjs";
+import {
+  inspectInstallations,
+  installSkills,
+  planInstallation,
+  targetDirectories,
+} from "../lib/install.mjs";
+
+export const recommendationContractVersion = "1.0.0";
+
+function usage() {
+  return `Apollo Agent Skills
+
+Usage:
+  apollo-skills setup [--target generic|claude|cursor|codex|copilot] [--project PATH] [--yes] [--force]
+  apollo-skills list [--json]
+  apollo-skills recommend <workflow> [--target TARGET] [--json]
+  apollo-skills add <skill...> [--target TARGET] [--project PATH] [--yes] [--force]
+  apollo-skills doctor [--target TARGET] [--project PATH] [--json]
+
+setup installs only the public onboarding skill. setup and add show the destination, version, credit behavior, and write behavior, then require confirmation unless --yes is provided.`;
+}
+
+function requireOptionValue(rest, index, option) {
+  const value = rest[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Option '${option}' requires a value.`);
+  return value;
+}
+
+function parseArguments(argv) {
+  const [command = "help", ...rest] = argv;
+  const options = { target: "generic", projectRoot: process.cwd(), yes: false, force: false, json: false };
+  const positional = [];
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const argument = rest[index];
+    if (argument === "--target") options.target = requireOptionValue(rest, index++, argument);
+    else if (argument === "--project") options.projectRoot = requireOptionValue(rest, index++, argument);
+    else if (argument === "--yes") options.yes = true;
+    else if (argument === "--force") options.force = true;
+    else if (argument === "--json") options.json = true;
+    else if (argument.startsWith("--")) throw new Error(`Unknown option '${argument}'.`);
+    else positional.push(argument);
+  }
+  return { command, options, positional };
+}
+
+function print(value, json) {
+  if (json) console.log(JSON.stringify(value, null, 2));
+  else console.log(value);
+}
+
+async function confirmInstall() {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error("Interactive confirmation is unavailable. Review the plan and rerun with --yes.");
+  }
+  const readline = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await readline.question("Install these skills? [y/N] ");
+    return /^y(?:es)?$/i.test(answer.trim());
+  } finally {
+    readline.close();
+  }
+}
+
+async function runInstallation({ catalog, skillIds, options }) {
+  if (!targetDirectories[options.target]) throw new Error(`Unknown target '${options.target}'.`);
+  const plan = planInstallation({
+    catalog,
+    skillIds,
+    target: options.target,
+    projectRoot: options.projectRoot,
+  });
+  console.log(`Target: ${plan.target}\nDestination: ${plan.destinationRoot}`);
+  plan.skills.forEach((skill) => {
+    console.log(`- ${skill.id} ${skill.version}\n  Credits: ${skill.credit_behavior}; Writes: ${skill.write_behavior}`);
+  });
+  if (!options.yes && !(await confirmInstall())) {
+    console.log("Installation cancelled.");
+    return;
+  }
+  const installed = await installSkills({
+    catalog,
+    skillIds,
+    target: options.target,
+    projectRoot: options.projectRoot,
+    overwrite: options.force,
+  });
+  installed.forEach((skill) => console.log(`Installed ${skill.id} ${skill.version} at ${skill.destination}`));
+}
+
+async function main() {
+  const { command, options, positional } = parseArguments(process.argv.slice(2));
+  if (command === "help" || command === "--help" || command === "-h") {
+    console.log(usage());
+    return;
+  }
+
+  const catalog = await loadCatalog();
+
+  if (command === "setup") {
+    if (positional.length > 0) throw new Error("setup does not accept skill names.");
+    await runInstallation({ catalog, skillIds: ["onboarding"], options });
+    return;
+  }
+
+  if (command === "list") {
+    if (positional.length > 0) throw new Error("list does not accept positional arguments.");
+    const rows = catalog.skills.map(({ id, version, description, credit_behavior, write_behavior }) => ({
+      id,
+      version,
+      description,
+      credit_behavior,
+      write_behavior,
+    }));
+    if (options.json) print(rows, true);
+    else rows.forEach((skill) => console.log(`${skill.id} ${skill.version}\n  ${skill.description}\n  Credits: ${skill.credit_behavior}; Writes: ${skill.write_behavior}`));
+    return;
+  }
+
+  if (command === "recommend") {
+    if (positional.length === 0) throw new Error("Describe the workflow to receive skill recommendations.");
+    if (!targetDirectories[options.target]) throw new Error(`Unknown target '${options.target}'.`);
+    const recommendations = recommendSkills(catalog, positional.join(" ")).map(({ score, ...skill }) => ({
+      skill_id: skill.id,
+      version: skill.version,
+      reason: skill.description,
+      visibility: skill.visibility,
+      required_tools: skill.required_tools,
+      install_command: `apollo-skills add ${skill.id} --target ${options.target}`,
+    }));
+    const response = { contract_version: recommendationContractVersion, recommendations };
+    if (options.json) print(response, true);
+    else if (recommendations.length === 0) console.log("No Apollo skill clearly matches that workflow.");
+    else recommendations.forEach((skill) => console.log(`${skill.skill_id}: ${skill.reason}\n  ${skill.install_command}`));
+    return;
+  }
+
+  if (command === "doctor") {
+    if (positional.length > 0) throw new Error("doctor does not accept positional arguments.");
+    const results = await inspectInstallations({
+      catalog,
+      target: options.target,
+      projectRoot: options.projectRoot,
+    });
+    if (options.json) print(results, true);
+    else results.forEach((result) => console.log(`${result.id}: ${result.status}${result.path ? ` (${result.path})` : ""}`));
+    return;
+  }
+
+  if (command === "add") {
+    await runInstallation({ catalog, skillIds: positional, options });
+    return;
+  }
+
+  throw new Error(`Unknown command '${command}'.\n\n${usage()}`);
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/catalog/skills.yaml
+++ b/catalog/skills.yaml
@@ -1,0 +1,77 @@
+{
+  "schema_version": "2",
+  "package_version": "0.3.0",
+  "mcp": {
+    "server": "apollo",
+    "endpoint": "https://mcp.apollo.io/mcp",
+    "authentication": "oauth2"
+  },
+  "surfaces": ["generic", "claude", "cursor", "codex", "copilot"],
+  "skills": [
+    {
+      "id": "onboarding",
+      "path": "skills/onboarding",
+      "version": "0.3.0",
+      "visibility": "public",
+      "owner": "devtools@apollo.io",
+      "description": "Connect to Apollo MCP with OAuth, verify access, and choose the right Apollo workflow.",
+      "triggers": ["onboarding", "get started", "connect Apollo", "set up Apollo", "verify Apollo", "Apollo skills"],
+      "required_tools": ["apollo_users_api_profile"],
+      "credit_behavior": "none",
+      "write_behavior": "read-only",
+      "supported_surfaces": ["generic", "claude", "cursor", "codex", "copilot"]
+    },
+    {
+      "id": "analytics",
+      "path": "skills/analytics",
+      "version": "0.3.0",
+      "visibility": "public",
+      "owner": "devtools@apollo.io",
+      "description": "Answer sales performance questions with Apollo analytics data.",
+      "triggers": ["analytics", "performance", "reply rate", "calls", "meetings", "pipeline", "sequence metrics"],
+      "required_tools": ["apollo_emailer_campaigns_search", "apollo_analytics_sync_report"],
+      "credit_behavior": "none",
+      "write_behavior": "read-only",
+      "supported_surfaces": ["generic", "claude", "cursor", "codex", "copilot"]
+    },
+    {
+      "id": "enrich-lead",
+      "path": "skills/enrich-lead",
+      "version": "0.3.0",
+      "visibility": "public",
+      "owner": "devtools@apollo.io",
+      "description": "Enrich a person and their company, then offer safe follow-up actions.",
+      "triggers": ["enrich", "lead", "contact details", "email", "phone", "linkedin", "company context"],
+      "required_tools": ["apollo_mixed_people_api_search", "apollo_people_match", "apollo_organizations_enrich", "apollo_contacts_create"],
+      "credit_behavior": "exact-confirmation-before-each-credit-action",
+      "write_behavior": "confirmation-before-contact-create",
+      "supported_surfaces": ["generic", "claude", "cursor", "codex", "copilot"]
+    },
+    {
+      "id": "prospect",
+      "path": "skills/prospect",
+      "version": "0.3.0",
+      "visibility": "public",
+      "owner": "devtools@apollo.io",
+      "description": "Turn an ideal-customer profile into a ranked and enriched lead list.",
+      "triggers": ["prospect", "ideal customer", "icp", "decision makers", "lead list", "find people", "find companies"],
+      "required_tools": ["apollo_mixed_companies_search", "apollo_users_api_profile", "apollo_organizations_bulk_enrich", "apollo_mixed_people_api_search", "apollo_people_bulk_match", "apollo_contacts_create"],
+      "credit_behavior": "exact-confirmation-with-balance-before-batch-enrichment",
+      "write_behavior": "confirmation-before-contact-create",
+      "supported_surfaces": ["generic", "claude", "cursor", "codex", "copilot"]
+    },
+    {
+      "id": "sequence-load",
+      "path": "skills/sequence-load",
+      "version": "0.3.0",
+      "visibility": "public",
+      "owner": "devtools@apollo.io",
+      "description": "Find, enrich, create, and enroll contacts into an Apollo sequence.",
+      "triggers": ["sequence", "enroll", "load contacts", "outreach", "campaign", "add leads"],
+      "required_tools": ["apollo_emailer_campaigns_search", "apollo_email_accounts_index", "apollo_mixed_people_api_search", "apollo_users_api_profile", "apollo_people_bulk_match", "apollo_contacts_create", "apollo_emailer_campaigns_add_contact_ids", "apollo_emailer_campaigns_remove_or_stop_contact_ids"],
+      "credit_behavior": "exact-confirmation-with-balance-before-batch-enrichment",
+      "write_behavior": "confirmation-before-enrollment",
+      "supported_surfaces": ["generic", "claude", "cursor", "codex", "copilot"]
+    }
+  ]
+}

--- a/contracts/apollo-mcp-tools.json
+++ b/contracts/apollo-mcp-tools.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1",
+  "verified_at": "2026-07-13",
+  "source": "Apollo MCP runtime tool catalog",
+  "notes": "Clients may qualify or hash tool identifiers. Canonical skills use the stable server-level names below.",
+  "tools": [
+    "apollo_analytics_sync_report",
+    "apollo_contacts_create",
+    "apollo_email_accounts_index",
+    "apollo_emailer_campaigns_add_contact_ids",
+    "apollo_emailer_campaigns_remove_or_stop_contact_ids",
+    "apollo_emailer_campaigns_search",
+    "apollo_mixed_companies_search",
+    "apollo_mixed_people_api_search",
+    "apollo_organizations_bulk_enrich",
+    "apollo_organizations_enrich",
+    "apollo_people_bulk_match",
+    "apollo_people_match",
+    "apollo_users_api_profile"
+  ]
+}
+

--- a/contracts/recommend-apollo-skills.schema.json
+++ b/contracts/recommend-apollo-skills.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/apolloio/apollo-mcp-plugin/contracts/recommend-apollo-skills.schema.json",
+  "title": "recommend_apollo_skills contract",
+  "description": "Versioned, read-only contract for recommending public Apollo skills without installing them.",
+  "type": "object",
+  "required": ["contract_version", "input", "output"],
+  "properties": {
+    "contract_version": { "const": "1.0.0" },
+    "input": {
+      "type": "object",
+      "required": ["workflow"],
+      "properties": {
+        "workflow": { "type": "string", "minLength": 1, "pattern": ".*\\S.*" },
+        "client_hint": { "enum": ["generic", "claude", "cursor", "codex", "copilot"] }
+      },
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "required": ["contract_version", "recommendations"],
+      "properties": {
+        "contract_version": { "const": "1.0.0" },
+        "recommendations": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "required": ["skill_id", "version", "reason", "visibility", "required_tools", "install_command"],
+            "properties": {
+              "skill_id": { "type": "string", "minLength": 1 },
+              "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
+              "reason": { "type": "string", "minLength": 1 },
+              "visibility": { "const": "public" },
+              "required_tools": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+              "install_command": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/skill-management.md
+++ b/docs/skill-management.md
@@ -1,0 +1,36 @@
+# Skill and MCP Management
+
+Apollo MCP tools and Apollo skills have separate delivery lifecycles:
+
+- The Apollo MCP server exposes authenticated capabilities at runtime.
+- A client discovers and activates installed `SKILL.md` instructions.
+- Package manifests connect a client to both layers.
+
+## Source of Truth
+
+`skills/<skill>/SKILL.md` is the only editable source for each public skill. Generated packages copy those directories exactly.
+
+`catalog/skills.yaml` records ownership, versions, public visibility, required Apollo tools, credit and write behavior, and supported clients.
+
+## Discovery and Installation
+
+The `apollo-skills` CLI provides:
+
+- `setup`: install only canonical onboarding
+- `list`: inspect the public catalog
+- `recommend`: return versioned, read-only workflow recommendations
+- `add`: install explicitly selected skills
+- `doctor`: compare installed files with canonical source
+
+No command silently installs a skill. `setup` and `add` require interactive confirmation or an explicit `--yes` after displaying the plan.
+
+## Release Gates
+
+Every release must:
+
+1. Validate portable frontmatter and catalog completeness.
+2. Reject client-qualified tool names and client-only argument syntax.
+3. Verify every referenced Apollo tool is declared in the catalog.
+4. Run focused cases for each skill, including credit and write safeguards.
+5. Build Claude, Cursor, Codex, Copilot, and generic packages from the same skill sources.
+6. Confirm excluded skills and local-only artifacts are absent from source and generated output.

--- a/evals/analytics/cases.json
+++ b/evals/analytics/cases.json
@@ -1,0 +1,20 @@
+{
+  "skill": "analytics",
+  "cases": [
+    {
+      "name": "sequence-reply-rate",
+      "prompt": "Which sequences had the highest reply rate in the last six months?",
+      "expected_skill": "analytics",
+      "expected_tools": ["apollo_analytics_sync_report"],
+      "assertions": ["uses last_6_months", "formats reply rate as a percentage", "does not write data"]
+    },
+    {
+      "name": "sequence-name-filter",
+      "prompt": "Show email performance for the Enterprise Outbound sequence this quarter.",
+      "expected_skill": "analytics",
+      "expected_tools": ["apollo_emailer_campaigns_search", "apollo_analytics_sync_report"],
+      "assertions": ["resolves the sequence ID before analytics", "uses current_quarter"]
+    }
+  ]
+}
+

--- a/evals/enrich-lead/cases.json
+++ b/evals/enrich-lead/cases.json
@@ -1,0 +1,20 @@
+{
+  "skill": "enrich-lead",
+  "cases": [
+    {
+      "name": "linkedin-enrichment",
+      "prompt": "Enrich this person from their LinkedIn URL.",
+      "expected_skill": "enrich-lead",
+      "expected_tools": ["apollo_people_match", "apollo_organizations_enrich"],
+      "assertions": ["uses the exact person-enrichment confirmation", "separately confirms company enrichment", "does not create a contact without confirmation"]
+    },
+    {
+      "name": "ambiguous-executive",
+      "prompt": "Enrich the CEO of Figma.",
+      "expected_skill": "enrich-lead",
+      "expected_tools": ["apollo_mixed_people_api_search", "apollo_people_match"],
+      "assertions": ["resolves ambiguity before enrichment", "presents alternatives when needed"]
+    }
+  ]
+}
+

--- a/evals/onboarding/cases.json
+++ b/evals/onboarding/cases.json
@@ -1,0 +1,19 @@
+{
+  "skill": "onboarding",
+  "cases": [
+    {
+      "name": "verify-existing-connection",
+      "prompt": "Help me get started with Apollo and verify that it is connected.",
+      "expected_skill": "onboarding",
+      "expected_tools": ["apollo_users_api_profile"],
+      "assertions": ["uses a read-only verification call", "reports relevant credit and permission state", "does not perform writes"]
+    },
+    {
+      "name": "route-to-workflow",
+      "prompt": "Apollo is connected. Which workflow should I use to build an ICP lead list?",
+      "expected_skill": "onboarding",
+      "expected_tools": [],
+      "assertions": ["routes to prospect", "explains the batch credit confirmation", "does not enrich during onboarding"]
+    }
+  ]
+}

--- a/evals/prospect/cases.json
+++ b/evals/prospect/cases.json
@@ -1,0 +1,20 @@
+{
+  "skill": "prospect",
+  "cases": [
+    {
+      "name": "complete-icp",
+      "prompt": "Find VPs of Engineering at US SaaS companies with 200-1000 employees.",
+      "expected_skill": "prospect",
+      "expected_tools": ["apollo_mixed_companies_search", "apollo_users_api_profile", "apollo_mixed_people_api_search", "apollo_people_bulk_match"],
+      "assertions": ["confirms company-search credit use", "checks remaining balance", "confirms the total enrichment scope"]
+    },
+    {
+      "name": "vague-icp",
+      "prompt": "Find me good prospects.",
+      "expected_skill": "prospect",
+      "expected_tools": [],
+      "assertions": ["asks for role and company criteria before searching"]
+    }
+  ]
+}
+

--- a/evals/sequence-load/cases.json
+++ b/evals/sequence-load/cases.json
@@ -1,0 +1,20 @@
+{
+  "skill": "sequence-load",
+  "cases": [
+    {
+      "name": "preview-before-enrollment",
+      "prompt": "Add 10 VP Sales prospects to the Q3 Outbound sequence.",
+      "expected_skill": "sequence-load",
+      "expected_tools": ["apollo_emailer_campaigns_search", "apollo_email_accounts_index", "apollo_mixed_people_api_search", "apollo_users_api_profile"],
+      "assertions": ["previews candidates", "checks remaining balance", "requires separate confirmation before enrichment and enrollment", "defaults enrollment to paused"]
+    },
+    {
+      "name": "list-sequences",
+      "prompt": "List my available sequences.",
+      "expected_skill": "sequence-load",
+      "expected_tools": ["apollo_emailer_campaigns_search"],
+      "assertions": ["does not enrich people", "does not enroll contacts"]
+    }
+  ]
+}
+

--- a/lib/catalog.mjs
+++ b/lib/catalog.mjs
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+export const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+export async function loadCatalog(root = repositoryRoot) {
+  const catalogPath = path.join(root, "catalog", "skills.yaml");
+  const catalog = parse(await readFile(catalogPath, "utf8"));
+
+  if (!catalog || !Array.isArray(catalog.skills)) {
+    throw new Error(`${catalogPath} must define a skills array.`);
+  }
+
+  return catalog;
+}
+
+export function findSkill(catalog, skillId) {
+  return catalog.skills.find((skill) => skill.id === skillId);
+}
+
+export function recommendSkills(catalog, workflow) {
+  const normalized = workflow.toLowerCase();
+  const words = new Set(normalized.match(/[a-z0-9]+/g) ?? []);
+
+  return catalog.skills
+    .map((skill) => {
+      const terms = [skill.id, skill.description, ...(skill.triggers ?? [])];
+      const score = terms.reduce((total, term) => {
+        const candidate = term.toLowerCase();
+        if (normalized.includes(candidate)) return total + 4;
+        const matches = (candidate.match(/[a-z0-9]+/g) ?? []).filter((word) =>
+          words.has(word),
+        );
+        return total + matches.length;
+      }, 0);
+      return { ...skill, score };
+    })
+    .filter((skill) => skill.score > 0)
+    .sort((left, right) =>
+      right.score - left.score || (left.id < right.id ? -1 : left.id > right.id ? 1 : 0))
+    .slice(0, 3);
+}

--- a/lib/install.mjs
+++ b/lib/install.mjs
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+import { access, cp, mkdir, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { findSkill, repositoryRoot } from "./catalog.mjs";
+
+export const targetDirectories = Object.freeze({
+  generic: path.join(".agents", "skills"),
+  claude: path.join(".claude", "skills"),
+  cursor: path.join(".cursor", "skills"),
+  codex: path.join(".agents", "skills"),
+  copilot: path.join(".github", "skills"),
+});
+
+function assertInsideProject(projectRoot, candidate) {
+  const root = path.resolve(projectRoot);
+  const resolved = path.resolve(candidate);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`Install destination must remain inside ${root}.`);
+  }
+  return resolved;
+}
+
+async function exists(candidate) {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hashFile(candidate) {
+  const contents = await readFile(candidate);
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+export function planInstallation({ catalog, skillIds, target, projectRoot }) {
+  const relativeDirectory = targetDirectories[target];
+  if (!relativeDirectory) {
+    throw new Error(`Unknown target '${target}'. Choose: ${Object.keys(targetDirectories).join(", ")}.`);
+  }
+  if (skillIds.length === 0) throw new Error("Select at least one skill to install.");
+  if (new Set(skillIds).size !== skillIds.length) {
+    throw new Error("Each skill may only be selected once per installation.");
+  }
+
+  const skills = skillIds.map((skillId) => {
+    const skill = findSkill(catalog, skillId);
+    if (!skill || skill.visibility !== "public") throw new Error(`Unknown public skill '${skillId}'.`);
+    if (!skill.supported_surfaces.includes(target)) {
+      throw new Error(`Skill '${skillId}' does not support target '${target}'.`);
+    }
+    return skill;
+  });
+
+  const destinationRoot = assertInsideProject(projectRoot, path.join(projectRoot, relativeDirectory));
+  return { destinationRoot, skills, target };
+}
+
+export async function installSkills({
+  catalog,
+  skillIds,
+  target = "generic",
+  projectRoot = process.cwd(),
+  sourceRoot = repositoryRoot,
+  overwrite = false,
+}) {
+  const plan = planInstallation({ catalog, skillIds, target, projectRoot });
+  const installed = [];
+
+  for (const skill of plan.skills) {
+    const destination = assertInsideProject(projectRoot, path.join(plan.destinationRoot, skill.id));
+    if ((await exists(destination)) && !overwrite) {
+      throw new Error(`Skill '${skill.id}' already exists at ${destination}. Use --force to update it.`);
+    }
+    const source = path.resolve(sourceRoot, skill.path, "SKILL.md");
+    if (!(await exists(source))) throw new Error(`Canonical skill '${skill.id}' is missing at ${source}.`);
+  }
+
+  await mkdir(plan.destinationRoot, { recursive: true });
+
+  for (const skill of plan.skills) {
+    const source = path.resolve(sourceRoot, skill.path);
+    const destination = assertInsideProject(projectRoot, path.join(plan.destinationRoot, skill.id));
+    const temporary = `${destination}.apollo-installing`;
+
+    await rm(temporary, { recursive: true, force: true });
+    await cp(source, temporary, { recursive: true, errorOnExist: true });
+    if (await exists(destination)) await rm(destination, { recursive: true, force: true });
+    await rename(temporary, destination);
+    installed.push({ id: skill.id, version: skill.version, destination });
+  }
+
+  return installed;
+}
+
+export async function inspectInstallations({
+  catalog,
+  target = "generic",
+  projectRoot = process.cwd(),
+  sourceRoot = repositoryRoot,
+}) {
+  const relativeDirectory = targetDirectories[target];
+  if (!relativeDirectory) throw new Error(`Unknown target '${target}'.`);
+  const destinationRoot = assertInsideProject(projectRoot, path.join(projectRoot, relativeDirectory));
+  const results = [];
+
+  for (const skill of catalog.skills.filter((candidate) => candidate.visibility === "public")) {
+    const sourceFile = path.resolve(sourceRoot, skill.path, "SKILL.md");
+    const installedFile = path.join(destinationRoot, skill.id, "SKILL.md");
+    if (!(await exists(installedFile))) {
+      results.push({ id: skill.id, status: "not-installed", version: skill.version });
+      continue;
+    }
+    const current = (await hashFile(sourceFile)) === (await hashFile(installedFile));
+    results.push({
+      id: skill.id,
+      status: current ? "current" : "different",
+      version: skill.version,
+      path: installedFile,
+    });
+  }
+
+  return results;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@apolloio/agent-skills",
+  "version": "0.3.0",
+  "description": "Portable Apollo Agent Skills and multi-client MCP plugin packages.",
+  "type": "module",
+  "bin": {
+    "apollo-skills": "./bin/apollo-skills.mjs"
+  },
+  "files": [
+    "bin",
+    "catalog",
+    "contracts",
+    "lib",
+    "skills"
+  ],
+  "scripts": {
+    "build": "node scripts/build-packages.mjs",
+    "check": "node scripts/validate.mjs && node --test",
+    "test": "node --test",
+    "validate": "node scripts/validate.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/apolloio/apollo-mcp-plugin",
+  "dependencies": {
+    "yaml": "^2.8.1"
+  }
+}

--- a/packages/codex/apollo/.codex-plugin/plugin.json
+++ b/packages/codex/apollo/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "apollo",
+  "version": "0.3.0",
+  "description": "Onboard, prospect, enrich leads, manage outreach sequences, and query sales analytics with Apollo MCP.",
+  "author": {
+    "name": "Apollo.io",
+    "email": "devtools@apollo.io",
+    "url": "https://www.apollo.io/"
+  },
+  "homepage": "https://docs.apollo.io/docs/apollo-mcp",
+  "repository": "https://github.com/apolloio/apollo-mcp-plugin",
+  "license": "MIT",
+  "keywords": ["apollo", "sales", "prospecting", "enrichment", "sequences", "analytics", "mcp"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Apollo",
+    "shortDescription": "Run Apollo sales workflows from Codex.",
+    "longDescription": "Connect and verify Apollo MCP, then use portable skills to prospect, enrich leads, manage sequences, and analyze sales activity.",
+    "developerName": "Apollo.io",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://www.apollo.io/",
+    "defaultPrompt": [
+      "Help me connect to Apollo and choose a safe first workflow.",
+      "Find decision-makers matching my ICP.",
+      "Enrich this lead and show company context."
+    ]
+  },
+  "mcpServers": "./.mcp.json"
+}

--- a/packages/codex/apollo/.mcp.json
+++ b/packages/codex/apollo/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "apollo": {
+      "type": "http",
+      "url": "https://mcp.apollo.io/mcp"
+    }
+  }
+}
+

--- a/packages/copilot/apollo/.mcp.json
+++ b/packages/copilot/apollo/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "apollo": {
+      "type": "http",
+      "url": "https://mcp.apollo.io/mcp"
+    }
+  }
+}
+

--- a/packages/copilot/apollo/plugin.json
+++ b/packages/copilot/apollo/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "apollo",
+  "version": "0.3.0",
+  "description": "Apollo onboarding and portable sales workflows for GitHub Copilot.",
+  "author": {
+    "name": "Apollo.io"
+  },
+  "homepage": "https://docs.apollo.io/docs/apollo-mcp",
+  "repository": "https://github.com/apolloio/apollo-mcp-plugin",
+  "license": "MIT",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,25 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
+
+packages:
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  yaml@2.9.0: {}
+

--- a/scripts/build-packages.mjs
+++ b/scripts/build-packages.mjs
@@ -1,0 +1,75 @@
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadCatalog, repositoryRoot } from "../lib/catalog.mjs";
+
+async function copySkills(root, destination) {
+  await cp(path.join(root, "skills"), path.join(destination, "skills"), { recursive: true });
+}
+
+async function copyPlugin(root, source, destination) {
+  await mkdir(destination, { recursive: true });
+  await cp(source, destination, { recursive: true });
+  await copySkills(root, destination);
+}
+
+function assertSafeOutput(root, outputRoot) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedOutput = path.resolve(outputRoot);
+  if (!resolvedOutput.startsWith(`${resolvedRoot}${path.sep}`) || path.basename(resolvedOutput) !== "dist") {
+    throw new Error(`Refusing to replace unsafe build directory: ${resolvedOutput}`);
+  }
+  return resolvedOutput;
+}
+
+export async function buildPackages({ root = repositoryRoot, outputRoot = path.join(root, "dist") } = {}) {
+  const output = assertSafeOutput(root, outputRoot);
+  const catalog = await loadCatalog(root);
+  await rm(output, { recursive: true, force: true });
+  await mkdir(output, { recursive: true });
+
+  const claudePlugin = path.join(output, "claude", "apollo");
+  await mkdir(path.join(claudePlugin, ".claude-plugin"), { recursive: true });
+  await cp(path.join(root, ".claude-plugin", "plugin.json"), path.join(claudePlugin, ".claude-plugin", "plugin.json"));
+  await cp(path.join(root, ".mcp.json"), path.join(claudePlugin, ".mcp.json"));
+  await copySkills(root, claudePlugin);
+  const claudeMarketplace = JSON.parse(await readFile(path.join(root, ".claude-plugin", "marketplace.json"), "utf8"));
+  claudeMarketplace.plugins[0].source = "./apollo";
+  await mkdir(path.join(output, "claude", ".claude-plugin"), { recursive: true });
+  await writeFile(
+    path.join(output, "claude", ".claude-plugin", "marketplace.json"),
+    `${JSON.stringify(claudeMarketplace, null, 2)}\n`,
+  );
+
+  const cursorPlugin = path.join(output, "cursor", "apollo");
+  await mkdir(path.join(cursorPlugin, ".cursor-plugin"), { recursive: true });
+  await cp(path.join(root, ".cursor-plugin", "plugin.json"), path.join(cursorPlugin, ".cursor-plugin", "plugin.json"));
+  await cp(path.join(root, ".mcp.json"), path.join(cursorPlugin, ".mcp.json"));
+  await copySkills(root, cursorPlugin);
+
+  await copyPlugin(root, path.join(root, "packages", "codex", "apollo"), path.join(output, "codex", "apollo"));
+  await copyPlugin(root, path.join(root, "packages", "copilot", "apollo"), path.join(output, "copilot", "apollo"));
+
+  const generic = path.join(output, "generic", "apollo");
+  await mkdir(generic, { recursive: true });
+  await copySkills(root, generic);
+  await cp(path.join(root, "catalog"), path.join(generic, "catalog"), { recursive: true });
+  await cp(path.join(root, "contracts"), path.join(generic, "contracts"), { recursive: true });
+  await cp(path.join(root, ".mcp.json"), path.join(generic, ".mcp.json"));
+
+  const manifest = {
+    package_version: catalog.package_version,
+    generated_from: "skills/",
+    packages: ["generic", "claude", "cursor", "codex", "copilot"],
+    public_skills: catalog.skills.map((skill) => skill.id),
+    private_skills_included: false,
+  };
+  await writeFile(path.join(output, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const manifest = await buildPackages();
+  console.log(`Built ${manifest.packages.length} package targets at dist/.`);
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,165 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+import { loadCatalog, repositoryRoot } from "../lib/catalog.mjs";
+import { targetDirectories } from "../lib/install.mjs";
+
+const allowedFrontmatter = new Set(["name", "description", "license", "metadata", "allowed-tools"]);
+const forbiddenSkillPatterns = [
+  [/mcp__/, "harness-qualified MCP tool name"],
+  [/\$ARGUMENTS/, "harness-specific argument placeholder"],
+  [/\/apollo:/, "Claude-specific slash command"],
+];
+const forbiddenOnboardingPatterns = [
+  [/replit/i, "client-specific hosted-development guidance"],
+  [/app[- ]?builder/i, "app-builder guidance"],
+  [/api[-_ ]?key/i, "API key guidance"],
+  [/\bsecrets?\b/i, "secrets-store guidance"],
+];
+
+function fail(errors) {
+  if (errors.length === 0) return;
+  throw new Error(`Validation failed:\n- ${errors.join("\n- ")}`);
+}
+
+function parseSkill(contents, skillId, errors) {
+  const match = contents.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) {
+    errors.push(`${skillId}: missing YAML frontmatter`);
+    return null;
+  }
+  let frontmatter;
+  try {
+    frontmatter = parse(match[1]);
+  } catch (error) {
+    errors.push(`${skillId}: invalid YAML frontmatter (${error.message})`);
+    return null;
+  }
+  for (const key of Object.keys(frontmatter)) {
+    if (!allowedFrontmatter.has(key)) errors.push(`${skillId}: non-portable frontmatter field '${key}'`);
+  }
+  return frontmatter;
+}
+
+async function validateManifestVersion(candidate, expectedVersion, errors) {
+  const manifest = JSON.parse(await readFile(candidate, "utf8"));
+  if (manifest.version !== expectedVersion) {
+    errors.push(`${path.relative(repositoryRoot, candidate)}: version ${manifest.version} does not match ${expectedVersion}`);
+  }
+}
+
+async function listFiles(candidate) {
+  const entries = await readdir(candidate, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(candidate, entry.name);
+    if (entry.isDirectory()) files.push(...(await listFiles(entryPath)));
+    else if (entry.isFile()) files.push(entryPath);
+  }
+  return files;
+}
+
+async function main() {
+  const catalog = await loadCatalog();
+  const errors = [];
+  const expectedSurfaces = Object.keys(targetDirectories);
+  const toolContract = JSON.parse(
+    await readFile(path.join(repositoryRoot, "contracts", "apollo-mcp-tools.json"), "utf8"),
+  );
+  const availableTools = new Set(toolContract.tools);
+
+  if (catalog.package_version !== "0.3.0") errors.push("catalog package_version must be 0.3.0");
+  if (JSON.stringify(catalog.surfaces) !== JSON.stringify(expectedSurfaces)) {
+    errors.push(`catalog surfaces must be: ${expectedSurfaces.join(", ")}`);
+  }
+
+  const skillDirectories = (await readdir(path.join(repositoryRoot, "skills"), { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  const catalogIds = catalog.skills.map((skill) => skill.id).sort();
+  if (JSON.stringify(skillDirectories) !== JSON.stringify(catalogIds)) {
+    errors.push(`catalog skills (${catalogIds.join(", ")}) do not match skills/ (${skillDirectories.join(", ")})`);
+  }
+
+  for (const skill of catalog.skills) {
+    if (skill.visibility !== "public") errors.push(`${skill.id}: public catalog may only contain public skills`);
+    if (JSON.stringify(skill.supported_surfaces) !== JSON.stringify(expectedSurfaces)) {
+      errors.push(`${skill.id}: supported surfaces must match the catalog surfaces`);
+    }
+    for (const tool of skill.required_tools) {
+      if (!availableTools.has(tool)) errors.push(`${skill.id}: tool ${tool} is absent from the MCP contract snapshot`);
+    }
+
+    const skillPath = path.join(repositoryRoot, skill.path, "SKILL.md");
+    const contents = await readFile(skillPath, "utf8");
+    const frontmatter = parseSkill(contents, skill.id, errors);
+    if (frontmatter) {
+      if (frontmatter.name !== skill.id) errors.push(`${skill.id}: frontmatter name mismatch`);
+      if (frontmatter.metadata?.version !== skill.version) errors.push(`${skill.id}: version mismatch`);
+      if (frontmatter.license !== "MIT") errors.push(`${skill.id}: license must be MIT`);
+    }
+    for (const [pattern, label] of forbiddenSkillPatterns) {
+      if (pattern.test(contents)) errors.push(`${skill.id}: contains ${label}`);
+    }
+    if (skill.id === "onboarding") {
+      for (const [pattern, label] of forbiddenOnboardingPatterns) {
+        if (pattern.test(contents)) errors.push(`onboarding: contains ${label}`);
+      }
+    }
+
+    const referencedTools = [...new Set(contents.match(/\bapollo_[a-z0-9_]+\b/g) ?? [])].sort();
+    const declaredTools = [...skill.required_tools].sort();
+    for (const tool of referencedTools.filter((tool) => !declaredTools.includes(tool))) {
+      errors.push(`${skill.id}: references undeclared tool ${tool}`);
+    }
+    for (const tool of declaredTools.filter((tool) => !referencedTools.includes(tool))) {
+      errors.push(`${skill.id}: declares unused tool ${tool}`);
+    }
+
+    const evalPath = path.join(repositoryRoot, "evals", skill.id, "cases.json");
+    const evals = JSON.parse(await readFile(evalPath, "utf8"));
+    if (!Array.isArray(evals.cases) || evals.cases.length < 2) errors.push(`${skill.id}: requires at least two eval cases`);
+    for (const testCase of evals.cases ?? []) {
+      if (testCase.expected_skill !== skill.id) errors.push(`${skill.id}: eval '${testCase.name}' has wrong expected skill`);
+      for (const tool of testCase.expected_tools ?? []) {
+        if (!declaredTools.includes(tool)) errors.push(`${skill.id}: eval '${testCase.name}' expects undeclared tool ${tool}`);
+      }
+    }
+  }
+
+  await validateManifestVersion(path.join(repositoryRoot, ".claude-plugin", "plugin.json"), catalog.package_version, errors);
+  await validateManifestVersion(path.join(repositoryRoot, ".cursor-plugin", "plugin.json"), catalog.package_version, errors);
+  await validateManifestVersion(path.join(repositoryRoot, "packages", "codex", "apollo", ".codex-plugin", "plugin.json"), catalog.package_version, errors);
+  await validateManifestVersion(path.join(repositoryRoot, "packages", "copilot", "apollo", "plugin.json"), catalog.package_version, errors);
+
+  const publicFiles = [
+    ...(await listFiles(path.join(repositoryRoot, "skills"))),
+    path.join(repositoryRoot, "catalog", "skills.yaml"),
+    ...(await listFiles(path.join(repositoryRoot, "packages"))),
+  ];
+  for (const candidate of publicFiles) {
+    const contents = await readFile(candidate, "utf8");
+    if (/replit-onboarding|"visibility"\s*:\s*"private"/i.test(contents)) {
+      errors.push(`${path.relative(repositoryRoot, candidate)}: excluded skill material detected`);
+    }
+  }
+
+  const recommendationContract = JSON.parse(
+    await readFile(path.join(repositoryRoot, "contracts", "recommend-apollo-skills.schema.json"), "utf8"),
+  );
+  if (recommendationContract.properties?.contract_version?.const !== "1.0.0") {
+    errors.push("recommend_apollo_skills contract_version must be 1.0.0");
+  }
+  if (!recommendationContract.required?.includes("contract_version")) {
+    errors.push("recommend_apollo_skills must require contract_version");
+  }
+
+  fail(errors);
+  console.log(`Validated ${catalog.skills.length} portable skills, ${expectedSurfaces.length} surfaces, and recommendation contract 1.0.0.`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/skills/analytics/SKILL.md
+++ b/skills/analytics/SKILL.md
@@ -1,34 +1,36 @@
 ---
 name: analytics
-description: "Instant sales analytics. Ask any performance question — emails, calls, meetings, tasks, opportunities, sequences, conversation intelligence — and get formatted tables with real Apollo data."
-user-invocable: true
-argument-hint: [your analytics question]
+description: "Instant sales analytics. Ask any performance question â€” emails, calls, meetings, tasks, opportunities, sequences, conversation intelligence â€” and get formatted tables with real Apollo data."
+license: MIT
+metadata:
+  author: Apollo.io
+  version: "0.3.0"
 ---
 
 # Analytics
 
-Answer any sales performance question using Apollo's analytics data. The user asks a question via "$ARGUMENTS".
+Answer any sales performance question using Apollo's analytics data. Treat the user's request as the analytics question.
 
 ## Examples
 
-- `/apollo:analytics How many emails did I send last 30 days?`
-- `/apollo:analytics Show me team call connect rate this quarter by rep`
-- `/apollo:analytics What's our email reply rate week over week for this year?`
-- `/apollo:analytics Break down pipeline and won amount by opportunity stage all time`
-- `/apollo:analytics Which sequences have the highest reply rate in the last 6 months?`
-- `/apollo:analytics Show me activity summary — emails, calls, meetings, tasks — for each rep this quarter`
-- `/apollo:analytics How are calls trending by day of week over the last 3 months?`
-- `/apollo:analytics Show me emails sent vs replied broken down by contact stage and email type`
+- `How many emails did I send last 30 days?`
+- `Show me team call connect rate this quarter by rep.`
+- `What's our email reply rate week over week for this year?`
+- `Break down pipeline and won amount by opportunity stage all time.`
+- `Which sequences have the highest reply rate in the last 6 months?`
+- `Show me activity summary â€” emails, calls, meetings, tasks â€” for each rep this quarter.`
+- `How are calls trending by day of week over the last 3 months?`
+- `Show me emails sent vs replied broken down by contact stage and email type.`
 
-## Step 1 — Interpret the Question
+## Step 1 â€” Interpret the Question
 
-Parse "$ARGUMENTS" to determine the following parameters:
+Parse the user's request to determine the following parameters:
 
 ---
 
 ### Metrics
 
-Select 1–15 metrics that match what the user is asking about. Always include the rate/percent version alongside raw counts when the user asks about performance.
+Select 1â€“15 metrics that match what the user is asking about. Always include the rate/percent version alongside raw counts when the user asks about performance.
 
 **Email**
 `num_emails_sent`, `num_emails_delivered`, `num_emails_opened`, `num_emails_clicked`, `num_emails_replied`, `num_emails_bounced`, `num_emails_unsubscribed`, `percent_emails_replied`, `num_contacts_emailed`, `num_contacts_opened`, `num_contacts_replied`
@@ -129,11 +131,11 @@ If the user wants a cross-tab (e.g. "by rep AND by sequence", "broken down by st
 
 ### Filters
 
-- "my data" / "for me" / "my performance" → `filters: { user_ids: ["current"] }`
-- Specific user by Apollo user ID → `filters: { user_ids: ["<user_id>"] }` (can combine: `["current", "user_id_1"]`)
-- "team" / no user mention → omit filters entirely (returns team-wide data)
-- Filter by team/subteam → `filters: { team_ids: ["<subteam_id>"] }`
-- Filter by sequence name → first call `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_search` to resolve the name to an ID, then pass `filters: { emailer_campaign_ids: ["<id>"] }`
+- "my data" / "for me" / "my performance" â†’ `filters: { user_ids: ["current"] }`
+- Specific user by Apollo user ID â†’ `filters: { user_ids: ["<user_id>"] }` (can combine: `["current", "user_id_1"]`)
+- "team" / no user mention â†’ omit filters entirely (returns team-wide data)
+- Filter by team/subteam â†’ `filters: { team_ids: ["<subteam_id>"] }`
+- Filter by sequence name â†’ first call the Apollo MCP tool `apollo_emailer_campaigns_search` to resolve the name to an ID, then pass `filters: { emailer_campaign_ids: ["<id>"] }`
 
 ---
 
@@ -146,14 +148,14 @@ sort: { metric: "<metric_name>", asc: false }
 Use `asc: true` for "lowest first" or "worst performing" queries.
 
 Two constraints:
-- Sort only applies when `group_by` is set — it has no effect on flat queries
+- Sort only applies when `group_by` is set â€” it has no effect on flat queries
 - The sort metric must be included in the `metrics` array
 
 ---
 
-## Step 2 — Call the Analytics Tool
+## Step 2 â€” Call the Analytics Tool
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_analytics_sync_report` with the parameters determined above.
+Use the Apollo MCP tool `apollo_analytics_sync_report` with the parameters determined above.
 
 If the question spans multiple independent dimensions (e.g. "show me email metrics by rep AND separately by sequence"), make two sequential calls.
 
@@ -161,28 +163,28 @@ If the question is ambiguous, make a reasonable default call first, then offer t
 
 ---
 
-## Step 3 — Present the Results
+## Step 3 â€” Present the Results
 
-**Flat response** (no group_by): Present as a clean two-column summary table — metric name and value.
+**Flat response** (no group_by): Present as a clean two-column summary table â€” metric name and value.
 
 **Grouped response** (group_by only): Present as a table with the dimension as the first column and metrics as subsequent columns. Highlight notable outliers (top performer, lowest rate, biggest gap).
 
 **Pivot response** (group_by + pivot_group_by): Present each metric as a separate labeled table. Add a brief summary sentence per table.
 
 Always:
-- Convert decimals to readable percentages (e.g. `0.14` → `14%`)
+- Convert decimals to readable percentages (e.g. `0.14` â†’ `14%`)
 - Format large numbers with commas
 - If the response says "Showing first N of M rows", mention the total count and offer to refine
-- Add 1–2 sentences of insight after the data (e.g. "Tuesday has the highest call volume at 355 calls", "Sarah Flores leads reply rate at 14%")
+- Add 1â€“2 sentences of insight after the data (e.g. "Tuesday has the highest call volume at 355 calls", "Sarah Flores leads reply rate at 14%")
 
 ---
 
-## Step 4 — Offer Follow-up Actions
+## Step 4 â€” Offer Follow-up Actions
 
-After presenting results, suggest 2–3 relevant next steps:
+After presenting results, suggest 2â€“3 relevant next steps:
 
-1. **Drill deeper** — break down by another dimension (e.g. "want to see this by rep?")
-2. **Change date range** — compare with a different time period
-3. **Add more metrics** — "want to add meetings or tasks to this view?"
-4. **Pivot view** — "want to cross-tab this — e.g. by rep × sequence?"
-5. **Export** — format as CSV-style table for copy-paste
+1. **Drill deeper** â€” break down by another dimension (e.g. "want to see this by rep?")
+2. **Change date range** â€” compare with a different time period
+3. **Add more metrics** â€” "want to add meetings or tasks to this view?"
+4. **Pivot view** â€” "want to cross-tab this â€” e.g. by rep Ã— sequence?"
+5. **Export** â€” format as CSV-style table for copy-paste

--- a/skills/enrich-lead/SKILL.md
+++ b/skills/enrich-lead/SKILL.md
@@ -1,58 +1,70 @@
 ---
 name: enrich-lead
 description: "Instant lead enrichment. Drop a name, company, LinkedIn URL, or email and get the full contact card with email, phone, title, company intel, and next actions."
-user-invocable: true
-argument-hint: [name, company, LinkedIn URL, or email]
+license: MIT
+metadata:
+  author: Apollo.io
+  version: "0.3.0"
 ---
 
 # Enrich Lead
 
-Turn any identifier into a full contact dossier. The user provides identifying info via "$ARGUMENTS".
+Turn any identifier in the user's request into a full contact dossier.
 
 ## Examples
 
-- `/apollo:enrich-lead Tim Zheng at Apollo`
-- `/apollo:enrich-lead https://www.linkedin.com/in/timzheng`
-- `/apollo:enrich-lead sarah@stripe.com`
-- `/apollo:enrich-lead Jane Smith, VP Engineering, Notion`
-- `/apollo:enrich-lead CEO of Figma`
+- `Enrich Tim Zheng at Apollo.`
+- `Enrich https://www.linkedin.com/in/timzheng.`
+- `Find the contact details for sarah@stripe.com.`
+- `Enrich Jane Smith, VP Engineering at Notion.`
+- `Enrich the CEO of Figma.`
 
-## Step 1 — Parse Input
+## Step 1 â€” Parse Input
 
-From "$ARGUMENTS", extract every identifier available:
+From the user's request, extract every identifier available:
 - First name, last name
 - Company name or domain
 - LinkedIn URL
 - Email address
 - Job title (use as a matching hint)
 
-If the input is ambiguous (e.g. just "CEO of Figma"), first use `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with relevant title and domain filters to identify the person, then proceed to enrichment.
+If the input is ambiguous (e.g. just "CEO of Figma"), first use the Apollo MCP tool `apollo_mixed_people_api_search` with relevant title and domain filters to identify the person, then proceed to enrichment.
 
-## Step 2 — Enrich the Person
+## Step 2 â€” Enrich the Person
 
-> **Credit warning**: Tell the user enrichment consumes 1 Apollo credit before calling.
+Before calling person enrichment, say exactly:
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_people_match` with all available identifiers:
+> "Enriching [name] will consume 1 credit (no charge if not found). Do you want to proceed?"
+
+Wait for explicit confirmation. Do not call the tool if the user has not confirmed.
+
+Use the Apollo MCP tool `apollo_people_match` with all available identifiers:
 - `first_name`, `last_name` if name is known
 - `domain` or `organization_name` if company is known
 - `linkedin_url` if LinkedIn is provided
 - `email` if email is provided
 - Set `reveal_personal_emails` to `true`
 
-If the match fails, try `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with looser filters and present the top 3 candidates. Ask the user to pick one, then re-enrich.
+If the match fails, try `apollo_mixed_people_api_search` with looser filters and present the top 3 candidates. Ask the user to pick one, then re-enrich.
 
-## Step 3 — Enrich Their Company
+## Step 3 â€” Enrich Their Company
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_organizations_enrich` with the person's company domain to pull firmographic context.
+Company enrichment is a separate credit-consuming action. Before calling it, say exactly:
 
-## Step 4 — Present the Contact Card
+> "Enriching [domain] will consume 1 credit (no charge if not found). Do you want to proceed?"
+
+Wait for explicit confirmation. If the user declines, present the person data without enriched company context.
+
+Use the Apollo MCP tool `apollo_organizations_enrich` with the person's company domain to pull firmographic context.
+
+## Step 4 â€” Present the Contact Card
 
 Format the output exactly like this:
 
 ---
 
 **[Full Name]** | [Title]
-[Company Name] · [Industry] · [Employee Count] employees
+[Company Name] Â· [Industry] Â· [Employee Count] employees
 
 | Field | Detail |
 |---|---|
@@ -70,11 +82,11 @@ Format the output exactly like this:
 
 ---
 
-## Step 5 — Offer Next Actions
+## Step 5 â€” Offer Next Actions
 
 Ask the user which action to take:
 
-1. **Save to Apollo** — Create this person as a contact via `mcp__claude_ai_Apollo_MCP__apollo_contacts_create` with `run_dedupe: true`
-2. **Add to a sequence** — Ask which sequence, then run the sequence-load flow
-3. **Find colleagues** — Search for more people at the same company using `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with `q_organization_domains_list` set to this company
-4. **Find similar people** — Search for people with the same title/seniority at other companies
+1. **Save to Apollo** â€” Create this person as a contact via `apollo_contacts_create` with `run_dedupe: true`
+2. **Add to a sequence** â€” Ask which sequence, then run the sequence-load flow
+3. **Find colleagues** â€” Search for more people at the same company using `apollo_mixed_people_api_search` with `q_organization_domains_list` set to this company
+4. **Find similar people** â€” Search for people with the same title/seniority at other companies

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: onboarding
+description: "Connect an AI client to Apollo MCP with OAuth, verify the connection and permissions, explain credit and write safeguards, and route the user to the right Apollo sales workflow. Use when getting started with Apollo, checking an Apollo connection, or deciding which Apollo skill to use."
+license: MIT
+metadata:
+  author: Apollo.io
+  version: "0.3.0"
+---
+
+# Apollo Onboarding
+
+Help the user establish and verify an Apollo MCP connection, then choose a workflow.
+
+## Connect
+
+1. Check whether the client already exposes Apollo MCP tools.
+2. If Apollo tools are unavailable, direct the user to the client's MCP connection settings and use:
+   - Server name: `apollo`
+   - Endpoint: `https://mcp.apollo.io/mcp`
+   - Authentication: OAuth 2.0
+3. Ask the user to complete the Apollo sign-in and return after the client reports a connected server.
+4. Never request, collect, display, or persist authentication credentials.
+
+Keep directions client-neutral unless the user identifies their client. Do not claim the connection succeeded until a verification call works.
+
+## Verify
+
+Call the read-only Apollo MCP tool `apollo_users_api_profile` with `include_credit_usage: true`.
+
+Report:
+- authenticated Apollo user and team, when returned
+- available credit balance, when returned
+- whether the connection is ready
+- any permission or plan limitation returned by Apollo
+
+If verification fails, quote the concise error, ask the user to reconnect through the client's MCP settings, and retry only after they confirm.
+
+## Explain Safety
+
+Before routing work, explain only the safeguards relevant to the selected workflow:
+
+- `analytics` is read-only.
+- `enrich-lead` confirms each credit-consuming enrichment separately.
+- `prospect` confirms the full enrichment count and current balance before batch enrichment.
+- `sequence-load` previews candidates, confirms credit use, and separately confirms enrollment. Enrollment defaults to paused unless the user explicitly requests active enrollment.
+
+Apollo permissions, plan limits, and credits still apply to every tool call.
+
+## Route
+
+Choose one workflow from the user's goal:
+
+| Goal | Skill |
+|---|---|
+| Analyze sales activity or performance | `analytics` |
+| Enrich one person and company | `enrich-lead` |
+| Build a ranked lead list from an ICP | `prospect` |
+| Add selected contacts to a sequence | `sequence-load` |
+
+Ask for the minimum missing input, then follow that skill's instructions. Do not perform a write or credit-consuming action during onboarding.

--- a/skills/prospect/SKILL.md
+++ b/skills/prospect/SKILL.md
@@ -1,69 +1,87 @@
 ---
 name: prospect
 description: "Full ICP-to-leads pipeline. Describe your ideal customer in plain English and get a ranked table of enriched decision-maker leads with emails and phone numbers."
-user-invocable: true
-argument-hint: [describe your ideal customer]
+license: MIT
+metadata:
+  author: Apollo.io
+  version: "0.3.0"
 ---
 
 # Prospect
 
-Go from an ICP description to a ranked, enriched lead list in one shot. The user describes their ideal customer via "$ARGUMENTS".
+Go from an ICP description in the user's request to a ranked, enriched lead list.
 
 ## Examples
 
-- `/apollo:prospect VP of Engineering at Series B+ SaaS companies in the US, 200-1000 employees`
-- `/apollo:prospect heads of marketing at e-commerce companies in Europe`
-- `/apollo:prospect CTOs at fintech startups, 50-500 employees, New York`
-- `/apollo:prospect procurement managers at manufacturing companies with 1000+ employees`
-- `/apollo:prospect SDR leaders at companies using Salesforce and Outreach`
+- `Find VPs of Engineering at Series B+ SaaS companies in the US with 200-1000 employees.`
+- `Find heads of marketing at e-commerce companies in Europe.`
+- `Find CTOs at fintech startups with 50-500 employees in New York.`
+- `Find procurement managers at manufacturing companies with 1000+ employees.`
+- `Find SDR leaders at companies using Salesforce and Outreach.`
 
-## Step 1 — Parse the ICP
+## Step 1 â€” Parse the ICP
 
-Extract structured filters from the natural language description in "$ARGUMENTS":
+Extract structured filters from the user's natural-language ICP description:
 
 **Company filters:**
-- Industry/vertical keywords → `q_organization_keyword_tags`
-- Employee count ranges → `organization_num_employees_ranges`
-- Company locations → `organization_locations`
-- Specific domains → `q_organization_domains_list`
+- Industry/vertical keywords â†’ `q_organization_keyword_tags`
+- Employee count ranges â†’ `organization_num_employees_ranges`
+- Company locations â†’ `organization_locations`
+- Specific domains â†’ `q_organization_domains_list`
 
 **Person filters:**
-- Job titles → `person_titles`
-- Seniority levels → `person_seniorities`
-- Person locations → `person_locations`
+- Job titles â†’ `person_titles`
+- Seniority levels â†’ `person_seniorities`
+- Person locations â†’ `person_locations`
 
 If the ICP is vague, ask 1-2 clarifying questions before proceeding. At minimum, you need a title/role and an industry or company size.
 
-## Step 2 — Search for Companies
+## Step 2 â€” Search for Companies
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_mixed_companies_search` with the company filters:
+Company search costs 1 credit when it returns results. Before calling the search tool, say exactly:
+
+> "This will consume 1 credit. Do you want to proceed?"
+
+Wait for explicit confirmation.
+
+Use the Apollo MCP tool `apollo_mixed_companies_search` with the company filters:
 - `q_organization_keyword_tags` for industry/vertical
 - `organization_num_employees_ranges` for size
 - `organization_locations` for geography
 - Set `per_page` to 25
 
-## Step 3 — Enrich Top Companies
+## Step 3 â€” Enrich Top Companies
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_organizations_bulk_enrich` with the domains from the top 10 results. This reveals revenue, funding, headcount, and firmographic data to help rank companies.
+Because this is a search-then-enrich workflow, call `apollo_users_api_profile` with `include_credit_usage: true`. Then say exactly:
 
-## Step 4 — Find Decision Makers
+> "Found [N] companies. Enriching all will use up to [N] credits. You have [X] credits remaining. Want to proceed, or narrow the scope?"
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with:
+Wait for explicit confirmation of the full company count. Do not confirm or enrich incrementally by batch.
+
+Use the Apollo MCP tool `apollo_organizations_bulk_enrich` with the domains from the top 10 results. This reveals revenue, funding, headcount, and firmographic data to help rank companies.
+
+## Step 4 â€” Find Decision Makers
+
+Use the Apollo MCP tool `apollo_mixed_people_api_search` with:
 - `person_titles` and `person_seniorities` from the ICP
 - `q_organization_domains_list` scoped to the enriched company domains
 - `per_page` set to 25
 
-## Step 5 — Enrich Top Leads
+## Step 5 â€” Enrich Top Leads
 
-> **Credit warning**: Tell the user exactly how many credits will be consumed before proceeding.
+Refresh the user's balance with `apollo_users_api_profile` and `include_credit_usage: true`. Then say exactly:
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_people_bulk_match` to enrich up to 10 leads per call with:
+> "Found [N] contacts. Enriching all will use up to [N] credits. You have [X] credits remaining. Want to proceed, or narrow the scope?"
+
+Wait for explicit confirmation of the full contact count. Do not start enriching in batches and confirm incrementally.
+
+Use the Apollo MCP tool `apollo_people_bulk_match` to enrich up to 10 leads per call with:
 - `first_name`, `last_name`, `domain` for each person
 - `reveal_personal_emails` set to `true`
 
 If more than 10 leads, batch into multiple calls.
 
-## Step 6 — Present the Lead Table
+## Step 6 â€” Present the Lead Table
 
 Show results in a ranked table:
 
@@ -73,18 +91,18 @@ Show results in a ranked table:
 |---|---|---|---|---|---|---|---|---|
 
 **ICP Fit** scoring:
-- **Strong** — title, seniority, company size, and industry all match
-- **Good** — 3 of 4 criteria match
-- **Partial** — 2 of 4 criteria match
+- **Strong** â€” title, seniority, company size, and industry all match
+- **Good** â€” 3 of 4 criteria match
+- **Partial** â€” 2 of 4 criteria match
 
 **Summary**: Found X leads across Y companies. Z credits consumed.
 
-## Step 7 — Offer Next Actions
+## Step 7 â€” Offer Next Actions
 
 Ask the user:
 
-1. **Save all to Apollo** — Bulk-create contacts via `mcp__claude_ai_Apollo_MCP__apollo_contacts_create` with `run_dedupe: true` for each lead
-2. **Load into a sequence** — Ask which sequence and run the sequence-load flow for these contacts
-3. **Deep-dive a company** — Run `/apollo:company-intel` on any company from the list
-4. **Refine the search** — Adjust filters and re-run
-5. **Export** — Format leads as a CSV-style table for easy copy-paste
+1. **Save all to Apollo** â€” Bulk-create contacts via `apollo_contacts_create` with `run_dedupe: true` for each lead
+2. **Load into a sequence** â€” Ask which sequence and run the sequence-load flow for these contacts
+3. **Deep-dive a company** â€” Ask for company intelligence on any company from the list
+4. **Refine the search** â€” Adjust filters and re-run
+5. **Export** â€” Format leads as a CSV-style table for easy copy-paste

--- a/skills/sequence-load/SKILL.md
+++ b/skills/sequence-load/SKILL.md
@@ -1,58 +1,60 @@
 ---
 name: sequence-load
 description: "Find leads matching criteria and bulk-add them to an Apollo outreach sequence. Handles enrichment, contact creation, deduplication, and enrollment in one flow."
-user-invocable: true
-argument-hint: [targeting criteria + sequence name]
+license: MIT
+metadata:
+  author: Apollo.io
+  version: "0.3.0"
 ---
 
 # Sequence Load
 
-Find, enrich, and load contacts into an outreach sequence — end to end. The user provides targeting criteria and a sequence name via "$ARGUMENTS".
+Find, enrich, and load contacts into an outreach sequence end to end. Read the targeting criteria and sequence name from the user's request.
 
 ## Examples
 
-- `/apollo:sequence-load add 20 VP Sales at SaaS companies to my "Q1 Outbound" sequence`
-- `/apollo:sequence-load SDR managers at fintech startups → Cold Outreach v2`
-- `/apollo:sequence-load list sequences` (shows all available sequences)
-- `/apollo:sequence-load directors of engineering, 500+ employees, US → Demo Follow-up`
-- `/apollo:sequence-load reload 15 more leads into "Enterprise Pipeline"`
+- `Add 20 VPs of Sales at SaaS companies to my "Q1 Outbound" sequence.`
+- `Load SDR managers at fintech startups into Cold Outreach v2.`
+- `List my available sequences.`
+- `Add US directors of engineering at companies with 500+ employees to Demo Follow-up.`
+- `Load 15 more leads into "Enterprise Pipeline".`
 
-## Step 1 — Parse Input
+## Step 1 â€” Parse Input
 
-From "$ARGUMENTS", extract:
+From the user's request, extract:
 
 **Targeting criteria:**
-- Job titles → `person_titles`
-- Seniority levels → `person_seniorities`
-- Industry keywords → `q_organization_keyword_tags`
-- Company size → `organization_num_employees_ranges`
-- Locations → `person_locations` or `organization_locations`
+- Job titles â†’ `person_titles`
+- Seniority levels â†’ `person_seniorities`
+- Industry keywords â†’ `q_organization_keyword_tags`
+- Company size â†’ `organization_num_employees_ranges`
+- Locations â†’ `person_locations` or `organization_locations`
 
 **Sequence info:**
-- Sequence name (text after "to", "into", or "→")
-- Volume — how many contacts to add (default: 10 if not specified)
+- Sequence name (text after "to", "into", or "â†’")
+- Volume â€” how many contacts to add (default: 10 if not specified)
 
 If the user just says "list sequences", skip to Step 2 and show all available sequences.
 
-## Step 2 — Find the Sequence
+## Step 2 â€” Find the Sequence
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_search` to find the target sequence:
+Use the Apollo MCP tool `apollo_emailer_campaigns_search` to find the target sequence:
 - Set `q_name` to the sequence name from input
 
 If no match or multiple matches:
 - Show all available sequences in a table: | Name | ID | Status |
 - Ask the user to pick one
 
-## Step 3 — Get Email Account
+## Step 3 â€” Get Email Account
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_email_accounts_index` to list linked email accounts.
+Use the Apollo MCP tool `apollo_email_accounts_index` to list linked email accounts.
 
-- If one account → use automatically
-- If multiple → show them and ask which to send from
+- If one account â†’ use automatically
+- If multiple â†’ show them and ask which to send from
 
-## Step 4 — Find Matching People
+## Step 4 â€” Find Matching People
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_mixed_people_api_search` with the targeting criteria.
+Use the Apollo MCP tool `apollo_mixed_people_api_search` with the targeting criteria.
 - Set `per_page` to the requested volume (or 10 by default)
 
 Present the candidates in a preview table:
@@ -60,35 +62,40 @@ Present the candidates in a preview table:
 | # | Name | Title | Company | Location |
 |---|---|---|---|---|
 
-Ask: **"Add these [N] contacts to [Sequence Name]? This will consume [N] Apollo credits for enrichment."**
+Call `apollo_users_api_profile` with `include_credit_usage: true`, then say exactly:
 
-Wait for confirmation before proceeding.
+> "Found [N] contacts. Enriching all will use up to [N] credits. You have [X] credits remaining. Want to proceed, or narrow the scope?"
 
-## Step 5 — Enrich and Create Contacts
+Wait for explicit confirmation of the full count before proceeding. Do not confirm incrementally by batch.
+
+## Step 5 â€” Enrich and Create Contacts
 
 For each approved lead:
 
-1. **Enrich** — Use `mcp__claude_ai_Apollo_MCP__apollo_people_bulk_match` (batch up to 10 per call) with:
+1. **Enrich** â€” Use `apollo_people_bulk_match` (batch up to 10 per call) with:
    - `first_name`, `last_name`, `domain` for each person
    - `reveal_personal_emails` set to `true`
 
-2. **Create contacts** — For each enriched person, use `mcp__claude_ai_Apollo_MCP__apollo_contacts_create` with:
+2. **Create contacts** â€” For each enriched person, use `apollo_contacts_create` with:
    - `first_name`, `last_name`, `email`, `title`, `organization_name`
    - `direct_phone` or `mobile_phone` if available
    - `run_dedupe` set to `true`
 
 Collect all created contact IDs.
 
-## Step 6 — Add to Sequence
+## Step 6 â€” Add to Sequence
 
-Use `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_add_contact_ids` with:
+Present a confirmation summary containing the sender email address, sequence name, number of contacts, and enrollment status. Default the status to `paused` so installation does not immediately start outreach. Wait for explicit confirmation before calling the enrollment tool.
+
+Use the Apollo MCP tool `apollo_emailer_campaigns_add_contact_ids` with:
 - `id`: the sequence ID
 - `emailer_campaign_id`: same sequence ID
 - `contact_ids`: array of created contact IDs
 - `send_email_from_email_account_id`: the chosen email account ID
 - `sequence_active_in_other_campaigns`: `false` (safe default)
+- `status`: `paused` unless the user explicitly confirms active enrollment
 
-## Step 7 — Confirm Enrollment
+## Step 7 â€” Confirm Enrollment
 
 Show a summary:
 
@@ -110,11 +117,11 @@ Show a summary:
 
 ---
 
-## Step 8 — Offer Next Actions
+## Step 8 â€” Offer Next Actions
 
 Ask the user:
 
-1. **Load more** — Find and add another batch of leads
-2. **Review sequence** — Show sequence details and all enrolled contacts
-3. **Remove a contact** — Use `mcp__claude_ai_Apollo_MCP__apollo_emailer_campaigns_remove_or_stop_contact_ids` to remove specific contacts
-4. **Pause a contact** — Re-add with `status: "paused"` and an `auto_unpause_at` date
+1. **Load more** â€” Find and add another batch of leads
+2. **Review sequence** â€” Show sequence details and all enrolled contacts
+3. **Remove a contact** â€” Use `apollo_emailer_campaigns_remove_or_stop_contact_ids` to remove specific contacts
+4. **Pause a contact** â€” Re-add with `status: "paused"` and an `auto_unpause_at` date

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { repositoryRoot } from "../lib/catalog.mjs";
+import { buildPackages } from "../scripts/build-packages.mjs";
+
+async function readTree(candidate) {
+  const entries = await readdir(candidate, { withFileTypes: true });
+  const contents = [];
+  for (const entry of entries) {
+    const entryPath = path.join(candidate, entry.name);
+    if (entry.isDirectory()) contents.push(...(await readTree(entryPath)));
+    else if (entry.isFile()) contents.push(await readFile(entryPath, "utf8"));
+  }
+  return contents;
+}
+
+test("package build produces the same five public skills for every target", async () => {
+  const manifest = await buildPackages();
+  assert.deepEqual(manifest.packages, ["generic", "claude", "cursor", "codex", "copilot"]);
+  assert.deepEqual(manifest.public_skills, ["onboarding", "analytics", "enrich-lead", "prospect", "sequence-load"]);
+  assert.equal(manifest.private_skills_included, false);
+
+  for (const target of manifest.packages) {
+    const skillRoot = path.join(repositoryRoot, "dist", target, "apollo", "skills");
+    assert.deepEqual((await readdir(skillRoot)).sort(), [...manifest.public_skills].sort());
+    assert.match(await readFile(path.join(skillRoot, "onboarding", "SKILL.md"), "utf8"), /name: onboarding/);
+    assert.match(await readFile(path.join(skillRoot, "prospect", "SKILL.md"), "utf8"), /name: prospect/);
+  }
+
+  const publicOutput = (await readTree(path.join(repositoryRoot, "dist"))).join("\n");
+  assert.doesNotMatch(
+    publicOutput,
+    /replit-onboarding|inbound-website-visitors|"visibility"\s*:\s*"private"|\.local-scratch|raw[-_ ](?:payload|output|capture)/i,
+  );
+});
+
+test("generic onboarding output excludes client-specific credential guidance", async () => {
+  await buildPackages();
+  const onboarding = await readFile(
+    path.join(repositoryRoot, "dist", "generic", "apollo", "skills", "onboarding", "SKILL.md"),
+    "utf8",
+  );
+  assert.doesNotMatch(onboarding, /replit|app[- ]?builder|api[-_ ]?key|\bsecrets?\b/i);
+});

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { loadCatalog, recommendSkills, repositoryRoot } from "../lib/catalog.mjs";
+
+test("catalog exposes the five canonical public skills on every public surface", async () => {
+  const catalog = await loadCatalog();
+  assert.equal(catalog.package_version, "0.3.0");
+  assert.deepEqual(catalog.surfaces, ["generic", "claude", "cursor", "codex", "copilot"]);
+  assert.deepEqual(catalog.skills.map((skill) => skill.id).sort(), [
+    "analytics",
+    "enrich-lead",
+    "onboarding",
+    "prospect",
+    "sequence-load",
+  ]);
+  assert.ok(catalog.skills.every((skill) => skill.visibility === "public"));
+  assert.ok(catalog.skills.every((skill) =>
+    assert.deepEqual(skill.supported_surfaces, catalog.surfaces) === undefined));
+});
+
+test("recommendations select the relevant skill without installing it", async () => {
+  const catalog = await loadCatalog();
+  const recommendations = recommendSkills(catalog, "Find decision makers matching my ICP");
+  assert.equal(recommendations[0].id, "prospect");
+  assert.ok(recommendations.length <= 3);
+
+  const broadWorkflow = catalog.skills.map((skill) =>
+    `${skill.id} ${skill.description}`).join(" ");
+  const broadRecommendations = recommendSkills(catalog, broadWorkflow);
+  assert.equal(broadRecommendations.length, 3);
+  assert.deepEqual(broadRecommendations, recommendSkills(catalog, broadWorkflow));
+});
+
+test("recommendation contract is explicitly versioned", async () => {
+  const schema = JSON.parse(await readFile(
+    path.join(repositoryRoot, "contracts", "recommend-apollo-skills.schema.json"),
+    "utf8",
+  ));
+  assert.equal(schema.properties.contract_version.const, "1.0.0");
+  assert.equal(schema.properties.output.properties.contract_version.const, "1.0.0");
+  assert.equal(schema.properties.input.properties.workflow.pattern, ".*\\S.*");
+  assert.equal(schema.properties.output.properties.recommendations.maxItems, 3);
+  assert.ok(schema.required.includes("contract_version"));
+});

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function runCli(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [path.join(root, "bin", "apollo-skills.mjs"), ...args], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("CLI lists all public skills", async () => {
+  const result = await runCli(["list", "--json"]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout).map((skill) => skill.id), [
+    "onboarding",
+    "analytics",
+    "enrich-lead",
+    "prospect",
+    "sequence-load",
+  ]);
+});
+
+test("CLI returns the versioned recommendation contract without installing", async () => {
+  const result = await runCli(["recommend", "find decision makers matching my ICP", "--target", "cursor", "--json"]);
+  assert.equal(result.code, 0);
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.contract_version, "1.0.0");
+  assert.equal(response.recommendations[0].skill_id, "prospect");
+  assert.match(response.recommendations[0].install_command, /--target cursor$/);
+});
+
+test("CLI refuses non-interactive installation without explicit consent", async (context) => {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), "apollo-cli-"));
+  context.after(() => rm(projectRoot, { recursive: true, force: true }));
+  const result = await runCli(["add", "analytics", "--project", projectRoot]);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /rerun with --yes/);
+  await assert.rejects(access(path.join(projectRoot, ".agents", "skills", "analytics", "SKILL.md")));
+});
+
+test("CLI setup installs only onboarding after explicit consent and doctor sees it", async (context) => {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), "apollo-cli-"));
+  context.after(() => rm(projectRoot, { recursive: true, force: true }));
+
+  const setup = await runCli(["setup", "--target", "copilot", "--project", projectRoot, "--yes"]);
+  assert.equal(setup.code, 0);
+  assert.match(setup.stdout, /Installed onboarding 0\.3\.0/);
+  await access(path.join(projectRoot, ".github", "skills", "onboarding", "SKILL.md"));
+  await assert.rejects(access(path.join(projectRoot, ".github", "skills", "analytics", "SKILL.md")));
+
+  const doctor = await runCli(["doctor", "--target", "copilot", "--project", projectRoot, "--json"]);
+  assert.equal(doctor.code, 0);
+  const statuses = JSON.parse(doctor.stdout);
+  assert.equal(statuses.find((skill) => skill.id === "onboarding").status, "current");
+  assert.equal(statuses.find((skill) => skill.id === "analytics").status, "not-installed");
+});

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { loadCatalog } from "../lib/catalog.mjs";
+import { inspectInstallations, installSkills, targetDirectories } from "../lib/install.mjs";
+
+test("installer exposes only the five public package targets", () => {
+  assert.deepEqual(Object.keys(targetDirectories), ["generic", "claude", "cursor", "codex", "copilot"]);
+});
+
+test("installer copies only explicitly selected skills", async (context) => {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), "apollo-skills-"));
+  context.after(() => rm(projectRoot, { recursive: true, force: true }));
+  const catalog = await loadCatalog();
+
+  const installed = await installSkills({ catalog, skillIds: ["analytics"], projectRoot, target: "generic" });
+  assert.equal(installed.length, 1);
+  const contents = await readFile(path.join(projectRoot, ".agents", "skills", "analytics", "SKILL.md"), "utf8");
+  assert.match(contents, /name: analytics/);
+
+  const status = await inspectInstallations({ catalog, projectRoot, target: "generic" });
+  assert.equal(status.find((skill) => skill.id === "analytics").status, "current");
+  assert.equal(status.find((skill) => skill.id === "prospect").status, "not-installed");
+});
+
+test("installer refuses to overwrite an existing skill without force", async (context) => {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), "apollo-skills-"));
+  context.after(() => rm(projectRoot, { recursive: true, force: true }));
+  const catalog = await loadCatalog();
+  await installSkills({ catalog, skillIds: ["enrich-lead"], projectRoot });
+  await assert.rejects(
+    installSkills({ catalog, skillIds: ["enrich-lead"], projectRoot }),
+    /already exists/,
+  );
+});
+
+test("installer validates the whole plan before copying any skill", async (context) => {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), "apollo-skills-"));
+  context.after(() => rm(projectRoot, { recursive: true, force: true }));
+  const catalog = await loadCatalog();
+  await installSkills({ catalog, skillIds: ["enrich-lead"], projectRoot });
+
+  await assert.rejects(
+    installSkills({ catalog, skillIds: ["analytics", "enrich-lead"], projectRoot }),
+    /already exists/,
+  );
+  await assert.rejects(
+    readFile(path.join(projectRoot, ".agents", "skills", "analytics", "SKILL.md"), "utf8"),
+    /ENOENT/,
+  );
+});


### PR DESCRIPTION
## Summary
- establish `skills/` and `catalog/skills.yaml` as the canonical public source for five portable Apollo skills
- add client-neutral onboarding plus Claude, Cursor, Codex, Copilot, and generic package builds
- add a consent-based installer and versioned read-only `recommend_apollo_skills` contract
- keep Replit-specific onboarding and visitor workflows out of every public output

## Safety
- installation requires explicit confirmation (`--yes` is an intentional override)
- recommendation returns at most three deterministic public skills and never installs or calls Apollo
- generic onboarding excludes Replit, app-builder, API-key, and secrets-store guidance

## Focused verification
- `CI=true pnpm check` (13/13 tests)
- `git diff --check`
- independent second-pass review: no blocker/high findings

## Follow-up
The Leadgenie draft PR consumes this contract and pins its catalog snapshot to commit `fbc9f28419a5fc23cc4ff531fee48acfa8066a1d`.