### PR TITLE
Add MCP Registry (server.json) + Glama manifest + publish workflow

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -20,20 +20,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Build mcp-publisher
+      - name: Download mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: "v1.8.0"
+          MCP_PUBLISHER_SHA256: "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf"
         run: |
-          git clone --depth 1 https://github.com/modelcontextprotocol/registry mcp-registry
-          cd mcp-registry && make publisher
-          cp cmd/publisher/bin/mcp-publisher ../mcp-publisher
-          cd .. && rm -rf mcp-registry
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
           chmod +x mcp-publisher
+          rm mcp-publisher.tar.gz
 
       - name: Authenticate with MCP Registry
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: MCP Registry publish failed on `${{ github.ref_name }}` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,39 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - server.json
+  workflow_dispatch:
+
+concurrency:
+  group: mcp-publishing
+  cancel-in-progress: true
+
+jobs:
+  publish-mcp:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build mcp-publisher
+        run: |
+          git clone --depth 1 https://github.com/modelcontextprotocol/registry mcp-registry
+          cd mcp-registry && make publisher
+          cp cmd/publisher/bin/mcp-publisher ../mcp-publisher
+          cd .. && rm -rf mcp-registry
+          chmod +x mcp-publisher
+
+      - name: Authenticate with MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["apolloio"]
+  "maintainers": ["apollotyler"]
 }

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["apolloio"]
+}

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/apolloio/apollo-mcp-plugin.git",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "0.1.1",
   "websiteUrl": "https://www.apollo.io/",
   "remotes": [
     {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.apolloio/apollo-mcp",
+  "title": "Apollo.io",
+  "description": "Prospect, enrich leads, and add to outreach sequences with Apollo.io. Search contacts and companies, enrich lead data, and manage sequences — all from your AI assistant.",
+  "repository": {
+    "url": "https://github.com/apolloio/apollo-mcp-plugin.git",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "websiteUrl": "https://www.apollo.io/",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.apollo.io/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `server.json` to register Apollo MCP with the [official MCP Registry](https://registry.modelcontextprotocol.io/) — remote streamable-HTTP transport at `https://mcp.apollo.io/mcp`, published under `io.github.apolloio/apollo-mcp`
- Adds `glama.json` to claim maintainership on Glama (Apollo is already indexed there as `io.apollo.mcp/apolloio`)
- Adds `.github/workflows/publish-mcp.yml` — triggers on any change to `server.json` on `main`, authenticates via GitHub OIDC, and publishes using the official `mcp-publisher` CLI

## Test plan

- [ ] Verify `https://mcp.apollo.io/mcp` is the correct production endpoint
- [ ] Confirm `apolloio` GitHub org has the `id-token: write` permission available for OIDC auth in Actions
- [ ] After merge, check the workflow run completes and the server appears at `https://registry.modelcontextprotocol.io/servers/io.github.apolloio/apollo-mcp`
- [ ] Bump `version` in `server.json` for any future registry updates (workflow only fires on changes to that file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)